### PR TITLE
HWKBTM-42 Instrument servlet and add wildfly based integration tests …

### DIFF
--- a/api/src/main/java/org/hawkular/btm/api/client/BusinessTransactionCollector.java
+++ b/api/src/main/java/org/hawkular/btm/api/client/BusinessTransactionCollector.java
@@ -113,6 +113,22 @@ public interface BusinessTransactionCollector {
     void producerEnd(String type, String uri, String id, Map<String,?> headers, Object... values);
 
     /**
+     * This method sets a property on the business transaction.
+     *
+     * @param name The property name
+     * @param value The property value
+     */
+    void setProperty(String name, String value);
+
+    /**
+     * This method sets a detail on the current node.
+     *
+     * @param name The detail name
+     * @param value The detail value
+     */
+    void setDetail(String name, String value);
+
+    /**
      * This method returns the session manager associated with the
      * current thread of execution.
      *

--- a/api/src/main/java/org/hawkular/btm/api/model/btxn/BusinessTransaction.java
+++ b/api/src/main/java/org/hawkular/btm/api/model/btxn/BusinessTransaction.java
@@ -83,6 +83,9 @@ public class BusinessTransaction {
     }
 
     /**
+     * This method returns properties that can be used to search for
+     * the business transaction.
+     *
      * @return the properties
      */
     public Map<String, String> getProperties() {

--- a/api/src/main/java/org/hawkular/btm/api/model/btxn/Component.java
+++ b/api/src/main/java/org/hawkular/btm/api/model/btxn/Component.java
@@ -140,8 +140,8 @@ public class Component extends InvocationNode {
     public String toString() {
         return "Component [componentType=" + componentType + ", operation=" + operation + ", uri=" + uri
                 + ", getRequest()=" + getRequest() + ", getResponse()=" + getResponse() + ", getNodes()=" + getNodes()
-                + ", getStartTime()=" + getStartTime() + ", getDuration()=" + getDuration() + ", getCorrelationIds()="
-                + getCorrelationIds() + "]";
+                + ", getStartTime()=" + getStartTime() + ", getDuration()=" + getDuration() + ", getDetails()="
+                + getDetails() + ", getCorrelationIds()=" + getCorrelationIds() + "]";
     }
 
 }

--- a/api/src/main/java/org/hawkular/btm/api/model/btxn/Consumer.java
+++ b/api/src/main/java/org/hawkular/btm/api/model/btxn/Consumer.java
@@ -116,8 +116,8 @@ public class Consumer extends InvocationNode {
     public String toString() {
         return "Consumer [endpointType=" + endpointType + ", uri=" + uri + ", getRequest()=" + getRequest()
                 + ", getResponse()=" + getResponse() + ", getNodes()=" + getNodes() + ", getStartTime()="
-                + getStartTime() + ", getDuration()=" + getDuration() + ", getCorrelationIds()=" + getCorrelationIds()
-                + "]";
+                + getStartTime() + ", getDuration()=" + getDuration() + ", getDetails()=" + getDetails()
+                + ", getCorrelationIds()=" + getCorrelationIds() + "]";
     }
 
 }

--- a/api/src/main/java/org/hawkular/btm/api/model/btxn/Node.java
+++ b/api/src/main/java/org/hawkular/btm/api/model/btxn/Node.java
@@ -16,7 +16,9 @@
  */
 package org.hawkular.btm.api.model.btxn;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.hawkular.btm.api.model.btxn.CorrelationIdentifier.Scope;
@@ -50,6 +52,9 @@ public abstract class Node {
     private long duration = 0;
 
     @JsonInclude(Include.NON_EMPTY)
+    private Map<String, String> details = new HashMap<String, String>();
+
+    @JsonInclude(Include.NON_EMPTY)
     private Set<CorrelationIdentifier> correlationIds = new HashSet<CorrelationIdentifier>();
 
     public Node() {
@@ -81,6 +86,22 @@ public abstract class Node {
      */
     public void setDuration(long duration) {
         this.duration = duration;
+    }
+
+    /**
+     * This method returns the specific details about the node.
+     *
+     * @return the details
+     */
+    public Map<String, String> getDetails() {
+        return details;
+    }
+
+    /**
+     * @param details the details to set
+     */
+    public void setDetails(Map<String, String> details) {
+        this.details = details;
     }
 
     /**
@@ -182,42 +203,46 @@ public abstract class Node {
         return false;
     }
 
+    /* (non-Javadoc)
+     * @see java.lang.Object#hashCode()
+     */
     @Override
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result
-                + ((correlationIds == null) ? 0 : correlationIds.hashCode());
+        result = prime * result + ((correlationIds == null) ? 0 : correlationIds.hashCode());
         result = prime * result + (int) (duration ^ (duration >>> 32));
+        result = prime * result + ((details == null) ? 0 : details.hashCode());
         result = prime * result + (int) (startTime ^ (startTime >>> 32));
         return result;
     }
 
+    /* (non-Javadoc)
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) {
+        if (this == obj)
             return true;
-        }
-        if (obj == null) {
+        if (obj == null)
             return false;
-        }
-        if (getClass() != obj.getClass()) {
+        if (getClass() != obj.getClass())
             return false;
-        }
         Node other = (Node) obj;
         if (correlationIds == null) {
-            if (other.correlationIds != null) {
+            if (other.correlationIds != null)
                 return false;
-            }
-        } else if (!correlationIds.equals(other.correlationIds)) {
+        } else if (!correlationIds.equals(other.correlationIds))
             return false;
-        }
-        if (duration != other.duration) {
+        if (duration != other.duration)
             return false;
-        }
-        if (startTime != other.startTime) {
+        if (details == null) {
+            if (other.details != null)
+                return false;
+        } else if (!details.equals(other.details))
             return false;
-        }
+        if (startTime != other.startTime)
+            return false;
         return true;
     }
 

--- a/api/src/main/java/org/hawkular/btm/api/model/btxn/Producer.java
+++ b/api/src/main/java/org/hawkular/btm/api/model/btxn/Producer.java
@@ -116,8 +116,8 @@ public class Producer extends InvocationNode {
     public String toString() {
         return "Producer [endpointType=" + endpointType + ", uri=" + uri + ", getRequest()=" + getRequest()
                 + ", getResponse()=" + getResponse() + ", getNodes()=" + getNodes() + ", getStartTime()="
-                + getStartTime() + ", getDuration()=" + getDuration() + ", getCorrelationIds()=" + getCorrelationIds()
-                + "]";
+                + getStartTime() + ", getDuration()=" + getDuration() + ", getDetails()=" + getDetails()
+                + ", getCorrelationIds()=" + getCorrelationIds() + "]";
     }
 
 }

--- a/api/src/main/java/org/hawkular/btm/api/model/btxn/Service.java
+++ b/api/src/main/java/org/hawkular/btm/api/model/btxn/Service.java
@@ -117,8 +117,8 @@ public class Service extends InvocationNode {
     public String toString() {
         return "Service [serviceType=" + serviceType + ", operation=" + operation + ", getRequest()=" + getRequest()
                 + ", getResponse()=" + getResponse() + ", getNodes()=" + getNodes() + ", getStartTime()="
-                + getStartTime() + ", getDuration()=" + getDuration() + ", getCorrelationIds()=" + getCorrelationIds()
-                + "]";
+                + getStartTime() + ", getDuration()=" + getDuration() + ", getDetails()=" + getDetails()
+                + ", getCorrelationIds()=" + getCorrelationIds() + "]";
     }
 
 }

--- a/client/btxn-collector/src/main/java/org/hawkular/btm/client/collector/DefaultBusinessTransactionCollector.java
+++ b/client/btxn-collector/src/main/java/org/hawkular/btm/client/collector/DefaultBusinessTransactionCollector.java
@@ -308,6 +308,56 @@ public class DefaultBusinessTransactionCollector implements BusinessTransactionC
         }
     }
 
+    /* (non-Javadoc)
+     * @see org.hawkular.btm.api.client.BusinessTransactionCollector#setProperty(java.lang.String,
+     *                          java.lang.String)
+     */
+    @Override
+    public void setProperty(String name, String value) {
+        if (log.isLoggable(Level.FINEST)) {
+            log.finest("Add property: name=" + name + " value=" + value);
+        }
+
+        try {
+            FragmentBuilder builder = fragmentManager.getFragmentBuilder();
+
+            if (builder != null) {
+                builder.getBusinessTransaction().getProperties().put(name, value);
+            } else if (log.isLoggable(warningLogLevel)) {
+                log.log(warningLogLevel, "No fragment builder for this thread", null);
+            }
+        } catch (Throwable t) {
+            if (log.isLoggable(warningLogLevel)) {
+                log.log(warningLogLevel, "setProperty failed", t);
+            }
+        }
+    }
+
+    /* (non-Javadoc)
+     * @see org.hawkular.btm.api.client.BusinessTransactionCollector#setDetail(java.lang.String,
+     *                          java.lang.String)
+     */
+    @Override
+    public void setDetail(String name, String value) {
+        if (log.isLoggable(Level.FINEST)) {
+            log.finest("Add property: name=" + name + " value=" + value);
+        }
+
+        try {
+            FragmentBuilder builder = fragmentManager.getFragmentBuilder();
+
+            if (builder != null) {
+                builder.getCurrentNode().getDetails().put(name, value);
+            } else if (log.isLoggable(warningLogLevel)) {
+                log.log(warningLogLevel, "No fragment builder for this thread", null);
+            }
+        } catch (Throwable t) {
+            if (log.isLoggable(warningLogLevel)) {
+                log.log(warningLogLevel, "setDetail failed", t);
+            }
+        }
+    }
+
     /**
      * @return the businessTransactionService
      */

--- a/client/btxn-instrumentation/src/main/resources/btm-restlet.json
+++ b/client/btxn-instrumentation/src/main/resources/btm-restlet.json
@@ -27,7 +27,7 @@
         },{
           "type": "InstrumentConsumer",
           "direction": "Request",
-          "endpointTypeExpression": "\"REST\"",
+          "endpointTypeExpression": "\"HTTP\"",
           "uriExpression": "$1.getResourceRef()",
           "idExpression": "id",
           "headersExpression": "headers.getValuesMap()"
@@ -49,7 +49,7 @@
         "actions": [{
           "type": "InstrumentConsumer",
           "direction": "Response",
-          "endpointTypeExpression": "\"REST\"",
+          "endpointTypeExpression": "\"HTTP\"",
           "uriExpression": "$1.getResourceRef()",
           "headersExpression": "headers.getValuesMap()"
         }]
@@ -74,7 +74,7 @@
         "actions": [{
           "type": "InstrumentProducer",
           "direction": "Request",
-          "endpointTypeExpression": "\"REST\"",
+          "endpointTypeExpression": "\"HTTP\"",
           "uriExpression": "$1.getResourceRef()",
           "idExpression": "id",
           "headersExpression": "headers.getValuesMap()"
@@ -100,7 +100,7 @@
         "actions": [{
           "type": "InstrumentProducer",
           "direction": "Response",
-          "endpointTypeExpression": "\"REST\"",
+          "endpointTypeExpression": "\"HTTP\"",
           "uriExpression": "$1.getResourceRef()",
           "headersExpression": "headers.getValuesMap()"
         }]

--- a/client/btxn-instrumentation/src/main/resources/btm-servlet.json
+++ b/client/btxn-instrumentation/src/main/resources/btm-servlet.json
@@ -1,0 +1,51 @@
+{
+  "instrumentation": {
+    "servlet": {
+      "description": "Servlet instrumentation",
+      "version": "1",
+      "rules": [{
+        "ruleName": "Servlet Consumer Start",
+        "interfaceName": "^javax.servlet.Servlet",
+        "methodName": "service",
+        "parameterTypes": [
+          "javax.servlet.http.HttpServletRequest",
+          "javax.servlet.http.HttpServletResponse"
+        ],
+        "location": "ENTRY",
+        "condition": "!$1.getRequestURI().startsWith(\"/auth\") && !$1.getRequestURI().startsWith(\"/hawkular/btm\")",
+        "actions": [{
+          "type": "InstrumentConsumer",
+          "direction": "Request",
+          "endpointTypeExpression": "\"HTTP\"",
+          "uriExpression": "$1.getRequestURL().toString()",
+          "idExpression": "$1.getHeader(\"Btmid\")"
+        },{
+          "type": "FreeFormAction",
+          "action": "collector().setDetail(\"principal\",$1.getRemoteUser())"
+        },{
+          "type": "FreeFormAction",
+          "action": "collector().setDetail(\"remoteAddr\",$1.getRemoteAddr())"
+        },{
+          "type": "FreeFormAction",
+          "action": "collector().setDetail(\"remoteHost\",$1.getRemoteHost())"
+        }]
+      },{
+        "ruleName": "Servlet Consumer End",
+        "interfaceName": "^javax.servlet.Servlet",
+        "methodName": "service",
+        "parameterTypes": [
+          "javax.servlet.http.HttpServletRequest",
+          "javax.servlet.http.HttpServletResponse"
+        ],
+        "location": "EXIT",
+        "condition": "!$1.getRequestURI().startsWith(\"/auth\") && !$1.getRequestURI().startsWith(\"/hawkular/btm\")",
+        "actions": [{
+          "type": "InstrumentConsumer",
+          "direction": "Response",
+          "endpointTypeExpression": "\"HTTP\"",
+          "uriExpression": "$1.getRequestURL().toString()"
+        }]
+      }]
+    }
+  }
+}

--- a/client/btxn-service-rest-client/src/main/java/org/hawkular/btm/btxn/service/rest/client/BusinessTransactionServiceRESTClient.java
+++ b/client/btxn-service-rest-client/src/main/java/org/hawkular/btm/btxn/service/rest/client/BusinessTransactionServiceRESTClient.java
@@ -120,11 +120,12 @@ public class BusinessTransactionServiceRESTClient implements BusinessTransaction
     @Override
     public void store(String tenantId, List<BusinessTransaction> btxns) throws Exception {
 
+        URL url = new URL(baseUrl + "transactions");
+
         if (log.isLoggable(Level.FINEST)) {
-            log.finest("Store btxns [tenant="+tenantId+"]: "+btxns);
+            log.finest("Store btxns [tenant="+tenantId+"][url="+url+"]: "+btxns);
         }
 
-        URL url = new URL(baseUrl + "transactions");
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();
 
         connection.setRequestMethod("POST");

--- a/pom.xml
+++ b/pom.xml
@@ -355,6 +355,9 @@
       <modules>
         <module>tests/client-camel</module>
         <module>tests/client-java</module>
+        <!-- Comment out until wildfly-maven-plugin 1.1.0.Alpha3 released
+        <module>tests/client-wildfly</module>
+        -->
         <module>tests/server-wildfly</module>
         <module>tests/test-btxn-service</module>
       </modules>

--- a/services/btxn-service-inmemory/src/main/java/org/hawkular/btm/btxn/service/inmemory/BusinessTransactionServiceInMemory.java
+++ b/services/btxn-service-inmemory/src/main/java/org/hawkular/btm/btxn/service/inmemory/BusinessTransactionServiceInMemory.java
@@ -65,7 +65,6 @@ public class BusinessTransactionServiceInMemory extends AbstractBusinessTransact
 
     @Override
     protected void doStore(String tenantId, BusinessTransaction btxn) throws Exception {
-
         synchronized (txns) {
             BusinessTransaction old = idMap.put(btxn.getId(), btxn);
 

--- a/tests/client-wildfly/pom.xml
+++ b/tests/client-wildfly/pom.xml
@@ -1,0 +1,371 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.hawkular.btm</groupId>
+    <artifactId>hawkular-btm</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>hawkular-btm-tests-client-wildfly</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Hawkular BTM::Tests::Client Wildfly</name>
+
+  <properties>
+    <hawkular.host>127.0.0.1</hawkular.host>
+    <hawkular.port>8080</hawkular.port>
+    <hawkular.base-uri>http://${hawkular.host}:${hawkular.port}</hawkular.base-uri>
+    <hawkular-btm.path>/hawkular/btm/</hawkular-btm.path>
+    <hawkular-btm.base-uri>${hawkular.base-uri}${hawkular-btm.path}</hawkular-btm.base-uri>
+    <!-- IMPORTANT: The port must be the port offset + 8080. -->
+    <wildfly.port.offset>1897</wildfly.port.offset>
+    <!-- IMPORTANT: The management port must be the port offset + 9990. -->
+    <wildfly.management.port>11887</wildfly.management.port>
+    <hawkular.home>${project.build.directory}/hawkular</hawkular.home>
+    <hawkular.btm.dist>${hawkular.home}/hawkular-accounts-distribution-${version.org.hawkular.accounts}</hawkular.btm.dist>
+    <hawkular.configuration>${hawkular.btm.dist}/standalone/configuration</hawkular.configuration>
+    <hawkular.data>${hawkular.btm.dist}/standalone/data</hawkular.data>
+    <hawkular.deployments>${hawkular.btm.dist}/standalone/deployments</hawkular.deployments>
+    <hawkular.lib>${hawkular.btm.dist}/standalone/lib</hawkular.lib>
+
+    <hawkular-btm.lib>${project.build.directory}/lib</hawkular-btm.lib>
+    <hawkular-btm.instrumentation>${project.basedir}/target/instrumentation</hawkular-btm.instrumentation>
+    <hawkular-btm.logging>${project.basedir}/src/test/configuration/logging.properties</hawkular-btm.logging>
+
+    <jboss.home>${project.build.directory}/hawkular-accounts-distribution-${version.org.hawkular.accounts}</jboss.home>
+    <server.config>standalone.xml</server.config>
+  </properties>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.hawkular.btm</groupId>
+      <artifactId>hawkular-btm-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.btm</groupId>
+      <artifactId>hawkular-btm-btxn-service-rest-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hawkular.btm</groupId>
+      <artifactId>hawkular-btm-client-manager</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.btm</groupId>
+      <artifactId>hawkular-btm-client-se-rest</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.accounts</groupId>
+      <artifactId>hawkular-accounts-distribution</artifactId>
+      <type>zip</type>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-example-servlet-rest-tomcat</artifactId>
+      <type>war</type>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.byteman</groupId>
+      <artifactId>byteman</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <configuration>
+          <excludes combine.children="append">
+            <exclude>**/*.data</exclude>
+            <exclude>**/*.btm</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>get-client-all</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.hawkular.btm</groupId>
+                  <artifactId>hawkular-btm-client-se-rest</artifactId>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>${hawkular-btm.lib}</outputDirectory>
+                  <destFileName>hawkular-btm-client-se-rest.jar</destFileName>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+          <execution>
+            <id>unpack</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.hawkular.btm</groupId>
+                  <artifactId>hawkular-btm-btxn-instrumentation</artifactId>
+                  <type>zip</type>
+                </artifactItem>
+              </artifactItems>
+              <outputDirectory>${hawkular-btm.instrumentation}</outputDirectory>
+            </configuration>
+          </execution>
+          <execution>
+            <id>unpack-hawkular</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>unpack-dependencies</goal>
+            </goals>
+            <configuration>
+              <includeGroupIds>org.hawkular.accounts</includeGroupIds>
+              <includeArtifactIds>hawkular-accounts-distribution</includeArtifactIds>
+              <outputDirectory>
+                ${hawkular.home}
+              </outputDirectory>
+            </configuration>
+          </execution>
+          <execution>
+            <id>update-hawkular-btm</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.hawkular.btm</groupId>
+                  <artifactId>hawkular-btm-btxn-service-rest</artifactId>
+                  <type>war</type>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>${hawkular.deployments}</outputDirectory>
+                  <destFileName>hawkular-btm-btxn-service-rest.war</destFileName>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.apache.camel</groupId>
+                  <artifactId>camel-example-servlet-rest-tomcat</artifactId>
+                  <type>war</type>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>${hawkular.deployments}</outputDirectory>
+                  <destFileName>camel-example-servlet-rest-tomcat.war</destFileName>
+                </artifactItem>
+
+                <!-- BTM client configuration -->
+                <artifactItem>
+                  <groupId>org.hawkular.btm</groupId>
+                  <artifactId>hawkular-btm-client-se-rest</artifactId>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>${hawkular.lib}</outputDirectory>
+                  <destFileName>hawkular-btm-client-se-rest.jar</destFileName>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-resources</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${hawkular.configuration}</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/test/resources/configuration</directory>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>xml-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>transform-standalone-xml</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>transform</goal>
+            </goals>
+            <configuration>
+              <transformationSets>
+                <transformationSet>
+                  <dir>${hawkular.configuration}</dir>
+                  <stylesheet>src/test/scripts/standalone.xsl</stylesheet>
+                  <includes>
+                    <include>standalone.xml</include>
+                  </includes>
+                  <outputDir>${hawkular.configuration}</outputDir>
+                </transformationSet>
+              </transformationSets>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <hawkular.host>${hawkular.host}</hawkular.host>
+            <hawkular.port>${hawkular.port}</hawkular.port>
+            <hawkular.base-uri>${hawkular.base-uri}</hawkular.base-uri>
+            <hawkular-btm.base-uri>${hawkular-btm.base-uri}</hawkular-btm.base-uri>
+          </systemPropertyVariables>
+        </configuration>
+        <executions>
+          <execution>
+            <id>exec-rest-tests</id>
+            <goals>
+              <goal>integration-test</goal>
+            </goals>
+            <configuration>
+              <includes>
+                <include>**/*Test.java</include>
+              </includes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>final-verify</id>
+            <goals>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.wildfly.plugins</groupId>
+        <artifactId>wildfly-maven-plugin</artifactId>
+        <version>1.1.0.Alpha3-SNAPSHOT</version>
+        <configuration>
+          <jboss-home>${hawkular.btm.dist}</jboss-home>
+          <javaOpts>
+            <javaOpt>-Djboss.modules.system.pkgs=org.jboss.byteman,org.hawkular.btm.client.manager,org.hawkular.btm.api.client</javaOpt>
+          </javaOpts>
+        </configuration>
+        <executions>
+          <execution>
+            <id>start-wildfly</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>start</goal>
+            </goals>
+            <configuration>
+              <javaOpts>
+                <javaOpt>-Xms64m</javaOpt>
+                <javaOpt>-Xmx512m</javaOpt>
+                <javaOpt>-Xss256k</javaOpt>
+                <javaOpt>-Djava.net.preferIPv4Stack=true</javaOpt>
+                <javaOpt>-Dsun.rmi.dgc.client.gcInterval=3600000</javaOpt>
+                <javaOpt>-Dsun.rmi.dgc.server.gcInterval=3600000</javaOpt>
+                <javaOpt>-Xdebug</javaOpt>
+                <javaOpt>-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8787</javaOpt>
+                <javaOpt>-Dkeycloak.import=${hawkular.configuration}/hawkular-realm.json</javaOpt>
+                <javaOpt>-Dorg.jboss.byteman.transform.all</javaOpt>
+                <javaOpt>-javaagent:${hawkular-btm.lib}/hawkular-btm-client-se-rest.jar=manager:org.hawkular.btm.client.manager.ClientManager,boot:${hawkular-btm.lib}/hawkular-btm-client-se-rest.jar,sys:${hawkular-btm.lib}/hawkular-btm-client-se-rest.jar</javaOpt>
+                <javaOpt>-Dorg.jboss.byteman.compileToBytecode</javaOpt>
+                <javaOpt>-Dhawkular-btm.config=${hawkular-btm.instrumentation}</javaOpt>
+                <javaOpt>-Dhawkular-btm.base-uri=http://localhost:8080/hawkular/btm</javaOpt>
+                <javaOpt>-Dhawkular-btm.username=jdoe</javaOpt>
+                <javaOpt>-Dhawkular-btm.password=password</javaOpt>
+                <javaOpt>-Djava.util.logging.config.file=${hawkular-btm.logging}</javaOpt>
+                <javaOpt>-Djboss.modules.system.pkgs=org.jboss.byteman,org.hawkular.btm.client.manager,org.hawkular.btm.api.client</javaOpt>
+                <javaOpt>-Dhawkular-btm.log.level=INFO</javaOpt>
+              </javaOpts>
+              <startup-timeout>120</startup-timeout>
+            </configuration>
+          </execution>
+          <execution>
+            <id>stop-wildfly</id>
+            <phase>post-integration-test</phase>
+            <goals>
+              <goal>shutdown</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/tests/client-wildfly/src/test/java/org/hawkular/btm/tests/client/wildfly/camel/ClientCamelServletTest.java
+++ b/tests/client-wildfly/src/test/java/org/hawkular/btm/tests/client/wildfly/camel/ClientCamelServletTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.btm.tests.wildfly;
+package org.hawkular.btm.tests.client.wildfly.camel;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -25,6 +25,7 @@ import java.net.URL;
 import java.util.List;
 
 import org.hawkular.btm.api.model.btxn.BusinessTransaction;
+import org.hawkular.btm.api.model.btxn.Consumer;
 import org.hawkular.btm.api.services.BusinessTransactionCriteria;
 import org.hawkular.btm.btxn.service.rest.client.BusinessTransactionServiceRESTClient;
 import org.junit.Test;
@@ -35,7 +36,7 @@ import org.junit.Test;
  *
  * @author gbrown
  */
-public class CamelRESTTest {
+public class ClientCamelServletTest {
 
     /**  */
     private static final String TEST_PASSWORD = "password";
@@ -105,8 +106,10 @@ public class CamelRESTTest {
 
         List<BusinessTransaction> btxns = service.query(null, criteria);
 
-        // TODO: Amend once collector capturing business transaction fragments
-        assertEquals(0, btxns.size());
+        assertEquals(1, btxns.size());
+
+        // Check top level node is a Consumer associated with the servlet
+        assertEquals(Consumer.class, btxns.get(0).getNodes().get(0).getClass());
     }
 
 }

--- a/tests/client-wildfly/src/test/scripts/standalone.xsl
+++ b/tests/client-wildfly/src/test/scripts/standalone.xsl
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xalan="http://xml.apache.org/xalan"
+                xmlns:ds="urn:jboss:domain:datasources:2.0"
+                xmlns:ra="urn:jboss:domain:resource-adapters:2.0"
+                xmlns:ejb3="urn:jboss:domain:ejb3:2.0"
+                version="2.0"
+                exclude-result-prefixes="xalan ds ra ejb3">
+
+  <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes" xalan:indent-amount="4" standalone="no"/>
+  <xsl:strip-space elements="*"/>
+
+  <!-- copy everything else as-is -->
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*" />
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Add new secure-deployment -->
+  <xsl:template match="node()[name(.)='secure-deployment'][last()]">
+
+    <xsl:variable name="newSecureDeployment">
+      <secure-deployment name="hawkular-btm-btxn-service-rest.war">
+        <realm>hawkular</realm>
+        <resource>hawkular-accounts-backend</resource>
+        <use-resource-role-mappings>true</use-resource-role-mappings>
+        <enable-cors>true</enable-cors>
+        <enable-basic-auth>true</enable-basic-auth>
+        <credential name="secret"><xsl:value-of select="node()[name(.)='credential'][last()]" /></credential>
+      </secure-deployment>
+    </xsl:variable>
+
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+    <xsl:copy-of select="$newSecureDeployment" />
+
+  </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
…to test it. Wildfly maven plugin has issue with not overwriting default properties, so fails to run the instrumented rules - fixed in snapshot version of plugin. Had to exclude /auth and /hawkular-btm URIs from servlet rules to avoid recursive reporting of interactions.

NOTE: Doesn't currently store the header values HWKBTM-44.