### PR TITLE
Fix integration test failing on travis - appears to be due to the wil…

### DIFF
--- a/tests/client-wildfly/src/test/java/org/hawkular/btm/tests/client/wildfly/camel/ClientCamelServletTest.java
+++ b/tests/client-wildfly/src/test/java/org/hawkular/btm/tests/client/wildfly/camel/ClientCamelServletTest.java
@@ -44,6 +44,17 @@ public class ClientCamelServletTest {
     private static final String TEST_USERNAME = "jdoe";
 
     @Test
+    public void testPlaceholder() {
+        try {
+            synchronized (this) {
+                wait(2000);
+            }
+        } catch (Exception e) {
+            fail("Failed to wait");
+        }
+    }
+
+    @Test
     @org.junit.Ignore("Ignore until wildfly-maven-plugin 1.1.0.Alpha3 released. See HWKBTM-47")
     public void testInvokeCamelRESTService() {
 


### PR DESCRIPTION
…dfly server having no actual tests to run, so closing down prematurely.