### PR TITLE
HWKBTM-117 xxxEnd failed messages being generated to due httpurlcon r…

### DIFF
--- a/client/btxn-instrumentation/src/main/resources/btmconfig/java/btm-httpurlcon.json
+++ b/client/btxn-instrumentation/src/main/resources/btmconfig/java/btm-httpurlcon.json
@@ -9,7 +9,7 @@
         "parameterTypes": [
         ],
         "location": "ENTRY",
-        "condition": "collector().session().activate($0.getURL().toString()) && $0.getRequestProperty(\"Hawkular-btid\") == null",
+        "condition": "!$0.connected && collector().session().activate($0.getURL().toString()) && $0.getRequestProperty(\"Hawkular-btid\") == null",
         "binds": [{
           "name": "id",
           "type": "java.lang.String",
@@ -42,7 +42,7 @@
         "parameterTypes": [
         ],
         "location": "ENTRY",
-        "condition": "collector().session().activate($0.getURL().toString()) && $0.getRequestProperty(\"Hawkular-btid\") == null",
+        "condition": "!$0.connected && collector().session().activate($0.getURL().toString()) && $0.getRequestProperty(\"Hawkular-btid\") == null",
         "binds": [{
           "name": "id",
           "type": "java.lang.String",
@@ -75,7 +75,7 @@
         "parameterTypes": [
         ],
         "location": "ENTRY",
-        "condition": "collector().session().activate($0.getURL().toString()) && $0.getRequestProperty(\"Hawkular-btid\") == null",
+        "condition": "!$0.connected && collector().session().activate($0.getURL().toString()) && $0.getRequestProperty(\"Hawkular-btid\") == null",
         "binds": [{
           "name": "id",
           "type": "java.lang.String",

--- a/client/btxn-instrumentation/src/main/resources/btmconfig/org/switchyard/btm-switchyard.json
+++ b/client/btxn-instrumentation/src/main/resources/btmconfig/org/switchyard/btm-switchyard.json
@@ -61,13 +61,13 @@
         "location": "ENTRY",
         "binds": [{
           "name": "content",
-          "type": "java.lang.Throwable",
+          "type": "java.lang.Object",
           "expression": "$1.getContent()"
         }],
         "condition": "collector().session().isActive()",
         "actions": [{
           "type": "FreeFormAction",
-          "action": "collector().setFault(simpleClassName(content), content.getMessage())"
+          "action": "collector().setFault(faultName(content), faultDescription(content))"
         },{
           "type": "InstrumentService",
           "direction": "Response",

--- a/client/client-manager/src/main/java/org/hawkular/btm/client/manager/faults/FaultDescriptor.java
+++ b/client/client-manager/src/main/java/org/hawkular/btm/client/manager/faults/FaultDescriptor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.btm.client.manager.faults;
+
+/**
+ * This interface represents a fault descriptor, providing information about a particular
+ * type of fault.
+ *
+ * @author gbrown
+ */
+public interface FaultDescriptor {
+
+    /**
+     * This method determines if the supplied fault is associated
+     * with the descriptor.
+     *
+     * @param fault The fault
+     * @return Whether this is the descriptor for the fault
+     */
+    boolean isValid(Object fault);
+
+    /**
+     * This method returns the fault name.
+     *
+     * @param fault The fault
+     * @return The name
+     */
+    String getName(Object fault);
+
+    /**
+     * This method returns the fault description.
+     *
+     * @param fault The fault
+     * @return The description
+     */
+    String getDescription(Object fault);
+
+}

--- a/client/client-manager/src/main/java/org/hawkular/btm/client/manager/faults/SOAPFaultDescriptor.java
+++ b/client/client-manager/src/main/java/org/hawkular/btm/client/manager/faults/SOAPFaultDescriptor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.btm.client.manager.faults;
+
+import javax.xml.soap.SOAPFault;
+
+/**
+ * This class provides the fault descriptor for a SOAP fault.
+ *
+ * @author gbrown
+ */
+public class SOAPFaultDescriptor implements FaultDescriptor {
+
+    /* (non-Javadoc)
+     * @see org.hawkular.btm.client.manager.faults.FaultDescriptor#isValid(java.lang.Object)
+     */
+    @Override
+    public boolean isValid(Object fault) {
+        return fault instanceof SOAPFault;
+    }
+
+    /* (non-Javadoc)
+     * @see org.hawkular.btm.client.manager.faults.FaultDescriptor#getName(java.lang.Object)
+     */
+    @Override
+    public String getName(Object fault) {
+        return ((SOAPFault)fault).getFaultCode();
+    }
+
+    /* (non-Javadoc)
+     * @see org.hawkular.btm.client.manager.faults.FaultDescriptor#getDescription(java.lang.Object)
+     */
+    @Override
+    public String getDescription(Object fault) {
+        return ((SOAPFault)fault).getFaultString();
+    }
+
+}

--- a/client/client-manager/src/main/java/org/hawkular/btm/client/manager/faults/ThrowableFaultDescriptor.java
+++ b/client/client-manager/src/main/java/org/hawkular/btm/client/manager/faults/ThrowableFaultDescriptor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.btm.client.manager.faults;
+
+/**
+ * This class provides the fault descriptor for a Throwable fault.
+ *
+ * @author gbrown
+ */
+public class ThrowableFaultDescriptor implements FaultDescriptor {
+
+    /* (non-Javadoc)
+     * @see org.hawkular.btm.client.manager.faults.FaultDescriptor#isValid(java.lang.Object)
+     */
+    @Override
+    public boolean isValid(Object fault) {
+        return fault instanceof Throwable;
+    }
+
+    /* (non-Javadoc)
+     * @see org.hawkular.btm.client.manager.faults.FaultDescriptor#getName(java.lang.Object)
+     */
+    @Override
+    public String getName(Object fault) {
+        return fault.getClass().getSimpleName();
+    }
+
+    /* (non-Javadoc)
+     * @see org.hawkular.btm.client.manager.faults.FaultDescriptor#getDescription(java.lang.Object)
+     */
+    @Override
+    public String getDescription(Object fault) {
+        return ((Throwable)fault).getMessage();
+    }
+
+}

--- a/client/client-manager/src/main/resources/META-INF/services/org.hawkular.btm.client.manager.faults.FaultDescriptor
+++ b/client/client-manager/src/main/resources/META-INF/services/org.hawkular.btm.client.manager.faults.FaultDescriptor
@@ -1,0 +1,2 @@
+org.hawkular.btm.client.manager.faults.ThrowableFaultDescriptor
+org.hawkular.btm.client.manager.faults.SOAPFaultDescriptor


### PR DESCRIPTION
…ules re-activating a fresh node. HWKBTM-118 Mechanism to allow pluggable fault descriptors - required because swyd faults were not always derived from Throwable