### PR TITLE
HWKBTM-183 Kibana3 does not support pagination in terms tables, so no…

### DIFF
--- a/client/btxn-instrumentation/src/main/resources/btmconfig/btm.json
+++ b/client/btxn-instrumentation/src/main/resources/btmconfig/btm.json
@@ -5,6 +5,7 @@
       "filter": {
         "exclusions": [
           "^/hawkular/btm",
+          "^/hawkular-btm-ui",
           "^/auth/"
         ]
       }

--- a/ui/kibana/src/main/kibana/config/app/dashboards/default.json
+++ b/ui/kibana/src/main/kibana/config/app/dashboards/default.json
@@ -9,15 +9,35 @@
         "0": {
           "id": 0,
           "color": "#7EB26D",
-          "alias": "All",
-          "pin": false,
+          "alias": "Consumers",
+          "pin": true,
           "type": "lucene",
           "enable": true,
-          "query": ""
+          "query": "type: \"Consumer\""
+        },
+        "1": {
+          "id": 1,
+          "color": "#1F78C1",
+          "alias": "Producers",
+          "pin": true,
+          "type": "lucene",
+          "enable": true,
+          "query": "type: \"Producer\""
+        },
+        "2": {
+          "id": 2,
+          "color": "#F9BA8F",
+          "alias": "Components",
+          "pin": true,
+          "type": "lucene",
+          "enable": true,
+          "query": "type: \"Component\""
         }
       },
       "ids": [
-        0
+        0,
+        1,
+        2
       ]
     },
     "filter": {
@@ -40,8 +60,7 @@
         }
       },
       "ids": [
-        0,
-        1
+        0
       ]
     }
   },
@@ -61,9 +80,11 @@
           "mode": "mean",
           "time_field": "timestamp",
           "queries": {
-            "mode": "all",
+            "mode": "selected",
             "ids": [
-              0
+              0,
+              1,
+              2
             ]
           },
           "value_field": "duration",
@@ -106,7 +127,7 @@
           },
           "title": "Response times",
           "scale": 1,
-          "y_format": "none",
+          "y_format": "short",
           "grid": {
             "max": null,
             "min": 0
@@ -146,14 +167,18 @@
           "queries": {
             "mode": "all",
             "ids": [
-              0
+              0,
+              1,
+              2
             ]
           },
           "field": "businessTransaction",
-          "exclude": [],
+          "exclude": [
+            ""
+          ],
           "missing": false,
           "other": false,
-          "size": 10,
+          "size": 20,
           "order": "term",
           "style": {
             "font-size": "10pt"
@@ -195,7 +220,9 @@
           "queries": {
             "mode": "all",
             "ids": [
-              0
+              0,
+              1,
+              2
             ]
           },
           "tmode": "terms",
@@ -223,7 +250,9 @@
           "queries": {
             "mode": "all",
             "ids": [
-              0
+              0,
+              1,
+              2
             ]
           },
           "value_field": "duration",
@@ -296,7 +325,9 @@
           "queries": {
             "mode": "all",
             "ids": [
-              0
+              0,
+              1,
+              2
             ]
           },
           "field": "uri",
@@ -315,7 +346,7 @@
           "chart": "pie",
           "counter_pos": "above",
           "spyable": true,
-          "title": "Operations",
+          "title": "URIs",
           "tmode": "terms",
           "tstat": "total",
           "valuefield": ""
@@ -366,14 +397,16 @@
           "queries": {
             "mode": "all",
             "ids": [
-              0
+              0,
+              1,
+              2
             ]
           },
           "field_list": true,
           "status": "Stable",
           "trimFactor": 300,
           "normTimes": true,
-          "title": "Documents",
+          "title": "Response Times",
           "all_fields": false,
           "localTime": false,
           "timeField": "@timestamp"


### PR DESCRIPTION
…t possible. User can increase the table size to view more business transaction names, or do a query that reduces the list by regex. Added instrumentation exclusion for HTTP traffic associated with BTM elasticsearch requests, and updated the default Kibana dashboard to separate data based on node type (e.g. consumer, producer and component).