### PR TITLE
HWKBTM-323 : Fix first-time build failures

### DIFF
--- a/feature-pack/standalone/pom.xml
+++ b/feature-pack/standalone/pom.xml
@@ -23,6 +23,7 @@
     <groupId>org.hawkular.btm</groupId>
     <artifactId>hawkular-btm</artifactId>
     <version>0.7.1.Final-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <artifactId>hawkular-btm-standalone-feature-pack</artifactId>

--- a/feature-pack/ui-patch/pom.xml
+++ b/feature-pack/ui-patch/pom.xml
@@ -24,6 +24,7 @@
     <groupId>org.hawkular.btm</groupId>
     <artifactId>hawkular-btm</artifactId>
     <version>0.7.1.Final-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <artifactId>hawkular-btm-integrated-ui-patch</artifactId>

--- a/server/cassandra/pom.xml
+++ b/server/cassandra/pom.xml
@@ -70,12 +70,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.logging</groupId>
-      <artifactId>jboss-logging-annotations</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <scope>provided</scope>

--- a/server/elasticsearch/pom.xml
+++ b/server/elasticsearch/pom.xml
@@ -77,12 +77,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.logging</groupId>
-      <artifactId>jboss-logging-annotations</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <scope>provided</scope>


### PR DESCRIPTION
This adds the relativePath to the feature-pack pom.xml so they are able
to locate the parent when it's not already in the M2 repo.
Also remove dup dependency on jboss-logging-annotations at some pom.xml