### PR TITLE
HWKBTM-319 : Add modules deps on templates module

### DIFF
--- a/ui/src/main/scripts/plugins/apm/ts/apmPlugin.ts
+++ b/ui/src/main/scripts/plugins/apm/ts/apmPlugin.ts
@@ -19,7 +19,8 @@
 /// <reference path="apmGlobals.ts"/>
 module APM {
 
-  export var _module = angular.module(APM.pluginName, ["xeditable","ui.bootstrap","angularUtils.directives.dirPagination"]);
+  export var _module = angular.module(APM.pluginName,
+    ["xeditable","ui.bootstrap","angularUtils.directives.dirPagination","hawkularbtm-templates"]);
 
   var tab = undefined;
 

--- a/ui/src/main/scripts/plugins/btm/ts/btmPlugin.ts
+++ b/ui/src/main/scripts/plugins/btm/ts/btmPlugin.ts
@@ -19,7 +19,7 @@
 /// <reference path="btmGlobals.ts"/>
 module BTM {
 
-  export var _module = angular.module(BTM.pluginName, ["xeditable","ui.bootstrap"]);
+  export var _module = angular.module(BTM.pluginName, ["xeditable","ui.bootstrap","hawkularbtm-templates"]);
 
   var tab = undefined;
 


### PR DESCRIPTION
The hawtio plugin modules (APM & BTM) must depend on the  templates
module, "hawkularbtm-templates", so that when they are loaded, templates
are already in the cache and thus not necessary to find them in the FS.