### PR TITLE
HWKBTM-318 : Fix empty dropdown in APM & BTxn info

### DIFF
--- a/ui/src/main/scripts/plugins/apm/ts/apm.ts
+++ b/ui/src/main/scripts/plugins/apm/ts/apm.ts
@@ -26,12 +26,12 @@ module APM {
       businessTransaction: undefined,
       hostName: $routeParams.hostName,
       properties: [],
-      startTime: -3600000,
-      endTime: "0"
+      startTime: '-3600000',
+      endTime: '0'
     };
 
     $scope.config = {
-      interval: 60000,
+      interval: '60000',
       maxRows: 10
     };
     

--- a/ui/src/main/scripts/plugins/btm/ts/btxninfo.ts
+++ b/ui/src/main/scripts/plugins/btm/ts/btxninfo.ts
@@ -33,13 +33,13 @@ module BTM {
       businessTransaction: $scope.businessTransactionName,
       properties: [],
       faults: [],
-      startTime: -3600000,
-      endTime: "0",
+      startTime: '-3600000',
+      endTime: '0',
       lowerBound: 0
     };
 
     $scope.config = {
-      interval: 60000,
+      interval: '60000',
       selectedProperty: undefined,
       lowerBoundDisplay: 0,
       prevLowerBoundDisplay: 0,


### PR DESCRIPTION
In order for angular to recognize and match the values for the select,
they must be a string instead of a number.