### PR TITLE
HWKBTM-327 : Instantiate controllers only on page

### DIFF
--- a/ui/src/main/scripts/plugins/apm/ts/apmPlugin.ts
+++ b/ui/src/main/scripts/plugins/apm/ts/apmPlugin.ts
@@ -35,8 +35,7 @@ module APM {
     $locationProvider.html5Mode(true);
     $routeProvider.
       when('/hawkular-ui/apm', {
-        templateUrl: 'plugins/apm/html/apm.html',
-        controller: 'APM.APMController'
+        templateUrl: 'plugins/apm/html/apm.html'
       });
   }]);
 

--- a/ui/src/main/scripts/plugins/btm/html/btxninfo.html
+++ b/ui/src/main/scripts/plugins/btm/html/btxninfo.html
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-md-12" ng-controller="BTM.BTxnConfigController">
+  <div class="col-md-12" ng-controller="BTM.BTxnInfoController">
     <h1><span style="color:grey">{{businessTransactionName}}</span></h1>
 
     <div class="form-group" >

--- a/ui/src/main/scripts/plugins/btm/ts/btmPlugin.ts
+++ b/ui/src/main/scripts/plugins/btm/ts/btmPlugin.ts
@@ -34,28 +34,22 @@ module BTM {
     $locationProvider.html5Mode(true);
     $routeProvider.
       when('/hawkular-ui/btm', {
-        templateUrl: 'plugins/btm/html/btm.html',
-        controller: 'BTM.BTMController'
+        templateUrl: 'plugins/btm/html/btm.html'
       }).
       when('/hawkular-ui/btm/candidates', {
-        templateUrl: 'plugins/btm/html/btxncandidates.html',
-        controller: 'BTM.BTMCandidatesController'
+        templateUrl: 'plugins/btm/html/btxncandidates.html'
       }).
       when('/hawkular-ui/btm/disabled', {
-        templateUrl: 'plugins/btm/html/btxndisabled.html',
-        controller: 'BTM.BTMDisabledController'
+        templateUrl: 'plugins/btm/html/btxndisabled.html'
       }).
       when('/hawkular-ui/btm/ignored', {
-        templateUrl: 'plugins/btm/html/btxnignored.html',
-        controller: 'BTM.BTMIgnoredController'
+        templateUrl: 'plugins/btm/html/btxnignored.html'
       }).
       when('/hawkular-ui/btm/config/:businesstransaction', {
-        templateUrl: 'plugins/btm/html/btxnconfig.html',
-        controller: 'BTM.BTxnConfigController'
+        templateUrl: 'plugins/btm/html/btxnconfig.html'
       }).
       when('/hawkular-ui/btm/info/:businesstransaction', {
-        templateUrl: 'plugins/btm/html/btxninfo.html',
-        controller: 'BTM.BTxnInfoController'
+        templateUrl: 'plugins/btm/html/btxninfo.html'
       });
   }]);
 


### PR DESCRIPTION
Controllers were being loaded both by the routeProvider and inside the
template. Keeping them only at the template, as Hawtio does in examples.