### PR TITLE
HWKBTM-316 : Fix Active BTxs refresh on console

### DIFF
--- a/ui/src/main/scripts/bower.json
+++ b/ui/src/main/scripts/bower.json
@@ -41,8 +41,8 @@
     "keycloak": "1.8.1",
     "angular-wizard": "0.6.1",
     "angular-clipboard": "1.3.0",
-    "angular-xeditable": "~0.1.9",
-    "angularUtils-pagination": "angular-utils-pagination#~0.9.2"
+    "angular-xeditable": "0.1.10",
+    "angular-utils-pagination": "0.9.4"
   },
   "devDependencies": {
     "hawtio-core-dts": "2.0.23"

--- a/ui/src/main/scripts/plugins/btm/html/btm.html
+++ b/ui/src/main/scripts/plugins/btm/html/btm.html
@@ -33,13 +33,13 @@
             </select>
           </div>
 
-          <div class="hk-url-item col-md-6" ng-hide="chart === 'None'" >
+          <div class="hk-txn-item col-md-6" ng-hide="chart === 'None'" >
             <div id="btxntxncountpiechart" ng-show="chart === 'TxnCount'"></div>
             <div id="btxnfaultcountpiechart" ng-show="chart === 'FaultCount'"></div>
           </div>
 
-          <div class="hk-url-item col-md-6" ng-repeat="btxn in businessTransactions | filter:query" >
-            <div class="panel panel-default hk-url-heading" ng-show="btxn.summary.level === 'All'">
+          <div class="hk-txn-item col-md-6" ng-repeat="btxn in businessTransactions track by btxn.summary.name | filter:query" >
+            <div class="panel panel-default hk-txn-heading" ng-show="btxn.summary.level === 'All'">
               <a href="/hawkular-ui/btm/info/{{btxn.summary.name}}">{{btxn.summary.name}}</a>
               <span class="hk-settings pull-right">
                 <a href="/hawkular-ui/btm/config/{{btxn.summary.name}}" ><i class="fa fa-cog"></i></a>

--- a/ui/src/main/scripts/plugins/btm/html/btm.html
+++ b/ui/src/main/scripts/plugins/btm/html/btm.html
@@ -22,7 +22,7 @@
         <ul class="list-group" >
           <br/>
           <div class="row" >
-            Search: <input ng-model="query"/>
+            Search: <input ng-model="query.name"/>
 
             <label style="width: 5%" ></label> <!-- TODO: Must be a better way -->
             <label for="chartType" style="width: 3%" >Chart:</label>
@@ -38,40 +38,40 @@
             <div id="btxnfaultcountpiechart" ng-show="chart === 'FaultCount'"></div>
           </div>
 
-          <div class="hk-txn-item col-md-6" ng-repeat="btxn in businessTransactions track by btxn.summary.name | filter:query" >
-            <div class="panel panel-default hk-txn-heading" ng-show="btxn.summary.level === 'All'">
-              <a href="/hawkular-ui/btm/info/{{btxn.summary.name}}">{{btxn.summary.name}}</a>
+          <div class="hk-txn-item col-md-6" ng-repeat="btxn in businessTransactions | filter:query track by btxn.name" ng-show="btxn.level === 'All'">
+            <div class="panel panel-default hk-txn-heading">
+              <a href="/hawkular-ui/btm/info/{{btxn.name}}">{{btxn.name}}</a>
               <span class="hk-settings pull-right">
-                <a href="/hawkular-ui/btm/config/{{btxn.summary.name}}" ><i class="fa fa-cog"></i></a>
+                <a href="/hawkular-ui/btm/config/{{btxn.name}}" ><i class="fa fa-cog"></i></a>
                 <a href="#" ng-click="deleteBusinessTxn(btxn)"><i class="fa fa-trash-o"></i></a>
               </span>
             </div>
 
-            <div class="panel panel-default hk-summary" ng-show="btxn.summary.level === 'All'">
+            <div class="panel panel-default hk-summary" ng-show="btxn.level === 'All'">
               <div class="row">
                 <div class="col-sm-3 hk-summary-item">
-                  <a href="/hawkular-ui/btm/info/{{btxn.summary.name}}">
+                  <a href="/hawkular-ui/btm/info/{{btxn.name}}">
                     <span class="hk-data" ng-show="btxn.count !== undefined">{{btxn.count}}</span>
                     <span class="hk-data spinner" ng-hide="btxn.count !== undefined" popover="Your data is being collected. You should see something in a few seconds." popover-trigger="mouseenter" popover-placement="bottom"></span>
                     <span class="hk-item">Transactions (per hour)</span>
                   </a>
                 </div>
                 <div class="col-sm-3 hk-summary-item">
-                  <a href="/hawkular-ui/btm/info/{{btxn.summary.name}}">
+                  <a href="/hawkular-ui/btm/info/{{btxn.name}}">
                     <span class="hk-data" ng-show="btxn.percentile95 !== undefined">{{btxn.percentile95}}</span>
                     <span class="hk-data spinner" ng-hide="btxn.percentile95 !== undefined" popover="Your data is being collected. You should see something in a few seconds." popover-trigger="mouseenter" popover-placement="bottom"></span>
                     <span class="hk-item">Completion (secs 95%)</span>
                   </a>
                 </div>
                 <div class="col-sm-3 hk-summary-item">
-                  <a href="/hawkular-ui/btm/info/{{btxn.summary.name}}">
+                  <a href="/hawkular-ui/btm/info/{{btxn.name}}">
                     <span class="hk-data" ng-show="btxn.faultcount !== undefined">{{btxn.faultcount}}</span>
                     <span class="hk-data spinner" ng-hide="btxn.faultcount !== undefined" popover="Your data is being collected. You should see something in a few seconds." popover-trigger="mouseenter" popover-placement="bottom"></span>
                     <span class="hk-item">Faults</span>
                   </a>
                 </div>
                 <div class="col-sm-3 hk-summary-item">
-                  <a href="/hawkular-ui/btm/info/{{btxn.summary.name}}">
+                  <a href="/hawkular-ui/btm/info/{{btxn.name}}">
                     <span class="hk-data" ng-show="btxn.alerts !== undefined">{{btxn.alerts}} <i class="fa fa-flag" ng-show="btxn.alerts > 0"></i></span>
                     <span class="hk-data spinner" ng-hide="btxn.alerts !== undefined" popover="Your data is being collected. You should see something in a few seconds." popover-trigger="mouseenter" popover-placement="bottom"></span>
                     <span class="hk-item">Alerts</span>

--- a/ui/src/main/scripts/plugins/btm/html/btxncandidates.html
+++ b/ui/src/main/scripts/plugins/btm/html/btxncandidates.html
@@ -57,7 +57,7 @@
           </div>
           <br/>
 
-          <div class="panel panel-default hk-url-heading">
+          <div class="panel panel-default hk-txn-heading">
             <div ng-repeat="uriinfo in unbounduris | filter:query" >
               <label>
                 <input type="checkbox" name="selectedURIs[]"

--- a/ui/src/main/scripts/plugins/btm/html/btxndisabled.html
+++ b/ui/src/main/scripts/plugins/btm/html/btxndisabled.html
@@ -23,14 +23,14 @@
         <ul class="list-group" >
           <br/>
           <div class="row" >
-            Search: <input ng-model="query"/>
+            Search: <input ng-model="query.name"/>
           </div>
 
-          <div class="hk-txn-item" ng-repeat="btxn in businessTransactions | filter:query" >
-            <div class="panel panel-default hk-txn-heading" ng-show="btxn.summary.level === 'None'">
-              <a href="/hawkular-ui/btm/info/{{btxn.summary.name}}">{{btxn.summary.name}}</a>
+          <div class="hk-txn-item" ng-repeat="btxn in businessTransactions | filter:query track by btxn.name" ng-show="btxn.level === 'None'">
+            <div class="panel panel-default hk-txn-heading">
+              <a href="/hawkular-ui/btm/info/{{btxn.name}}">{{btxn.name}}</a>
               <span class="hk-settings pull-right">
-                <a href="/hawkular-ui/btm/config/{{btxn.summary.name}}" ><i class="fa fa-cog"></i></a>
+                <a href="/hawkular-ui/btm/config/{{btxn.name}}" ><i class="fa fa-cog"></i></a>
                 <a href="#" ng-click="deleteBusinessTxn(btxn)"><i class="fa fa-trash-o"></i></a>
               </span>
             </div>

--- a/ui/src/main/scripts/plugins/btm/html/btxndisabled.html
+++ b/ui/src/main/scripts/plugins/btm/html/btxndisabled.html
@@ -26,8 +26,8 @@
             Search: <input ng-model="query"/>
           </div>
 
-          <div class="hk-url-item" ng-repeat="btxn in businessTransactions | filter:query" >
-            <div class="panel panel-default hk-url-heading" ng-show="btxn.summary.level === 'None'">
+          <div class="hk-txn-item" ng-repeat="btxn in businessTransactions | filter:query" >
+            <div class="panel panel-default hk-txn-heading" ng-show="btxn.summary.level === 'None'">
               <a href="/hawkular-ui/btm/info/{{btxn.summary.name}}">{{btxn.summary.name}}</a>
               <span class="hk-settings pull-right">
                 <a href="/hawkular-ui/btm/config/{{btxn.summary.name}}" ><i class="fa fa-cog"></i></a>

--- a/ui/src/main/scripts/plugins/btm/html/btxnignored.html
+++ b/ui/src/main/scripts/plugins/btm/html/btxnignored.html
@@ -23,14 +23,14 @@
         <ul class="list-group" >
           <br/>
           <div class="row" >
-            Search: <input ng-model="query"/>
+            Search: <input ng-model="query.name"/>
           </div>
 
-          <div class="hk-txn-item" ng-repeat="btxn in businessTransactions | filter:query" >
-            <div class="panel panel-default hk-txn-heading" ng-show="btxn.summary.level === 'Ignore'">
-              <a href="/hawkular-ui/btm/info/{{btxn.summary.name}}">{{btxn.summary.name}}</a>
+          <div class="hk-txn-item" ng-repeat="btxn in businessTransactions | filter:query track by btxn.name" ng-show="btxn.level === 'Ignore'">
+            <div class="panel panel-default hk-txn-heading">
+              <a href="/hawkular-ui/btm/info/{{btxn.name}}">{{btxn.name}}</a>
               <span class="hk-settings pull-right">
-                <a href="/hawkular-ui/btm/config/{{btxn.summary.name}}" ><i class="fa fa-cog"></i></a>
+                <a href="/hawkular-ui/btm/config/{{btxn.name}}" ><i class="fa fa-cog"></i></a>
                 <a href="#" ng-click="deleteBusinessTxn(btxn)"><i class="fa fa-trash-o"></i></a>
               </span>
             </div>

--- a/ui/src/main/scripts/plugins/btm/html/btxnignored.html
+++ b/ui/src/main/scripts/plugins/btm/html/btxnignored.html
@@ -26,8 +26,8 @@
             Search: <input ng-model="query"/>
           </div>
 
-          <div class="hk-url-item" ng-repeat="btxn in businessTransactions | filter:query" >
-            <div class="panel panel-default hk-url-heading" ng-show="btxn.summary.level === 'Ignore'">
+          <div class="hk-txn-item" ng-repeat="btxn in businessTransactions | filter:query" >
+            <div class="panel panel-default hk-txn-heading" ng-show="btxn.summary.level === 'Ignore'">
               <a href="/hawkular-ui/btm/info/{{btxn.summary.name}}">{{btxn.summary.name}}</a>
               <span class="hk-settings pull-right">
                 <a href="/hawkular-ui/btm/config/{{btxn.summary.name}}" ><i class="fa fa-cog"></i></a>

--- a/ui/src/main/scripts/plugins/btm/less/main.less
+++ b/ui/src/main/scripts/plugins/btm/less/main.less
@@ -1612,10 +1612,10 @@ td.hk-actions-two {
   }
 }
 
-.hk-url-item {
+.hk-txn-item {
   margin-top: @grid-gutter-width/4*3;
 
-  .hk-url-heading {
+  .hk-txn-heading {
     margin-bottom: 1px;
     padding: @grid-gutter-width/4;
 
@@ -1641,7 +1641,7 @@ td.hk-actions-two {
   }
 }
 
-.hk-url-info .row-table:first-child {
+.hk-txn-info .row-table:first-child {
   padding-top: @grid-gutter-width/2;
 }
 

--- a/ui/src/main/scripts/plugins/btm/ts/btm.ts
+++ b/ui/src/main/scripts/plugins/btm/ts/btm.ts
@@ -37,7 +37,6 @@ module BTM {
 
         var allPromises = [];
         for (var i = 0; i < resp.data.length; i++) {
-          resp.data[i].summary = resp.data[i];
           angular.extend(allPromises, $scope.getBusinessTxnDetails(resp.data[i]));
         }
 
@@ -67,7 +66,7 @@ module BTM {
     $scope.getBusinessTxnDetails = function(btxn) {
       var promises = [];
 
-      var countPromise = $http.get('/hawkular/btm/analytics/completion/count?businessTransaction='+btxn.summary.name);
+      var countPromise = $http.get('/hawkular/btm/analytics/completion/count?businessTransaction='+btxn.name);
       promises.push(countPromise);
       countPromise.then(function(resp) {
         btxn.count = resp.data;
@@ -76,7 +75,7 @@ module BTM {
       });
 
 
-      var pct95Promise = $http.get('/hawkular/btm/analytics/completion/percentiles?businessTransaction='+btxn.summary.name);
+      var pct95Promise = $http.get('/hawkular/btm/analytics/completion/percentiles?businessTransaction='+btxn.name);
       promises.push(pct95Promise);
       pct95Promise.then(function(resp) {
         if (resp.data.percentiles[95] > 0) {
@@ -88,7 +87,7 @@ module BTM {
         console.log("Failed to get completion percentiles: "+JSON.stringify(resp));
       });
 
-      var faultsPromise = $http.get('/hawkular/btm/analytics/completion/faultcount?businessTransaction='+btxn.summary.name);
+      var faultsPromise = $http.get('/hawkular/btm/analytics/completion/faultcount?businessTransaction='+btxn.name);
       promises.push(faultsPromise);
       faultsPromise.then(function(resp) {
         btxn.faultcount = resp.data;
@@ -96,7 +95,7 @@ module BTM {
         console.log("Failed to get fault count: "+JSON.stringify(resp));
       });
 
-      var alertsPromise = $http.get('/hawkular/btm/analytics/alerts/count/'+btxn.summary.name);
+      var alertsPromise = $http.get('/hawkular/btm/analytics/alerts/count/'+btxn.name);
       promises.push(alertsPromise);
       alertsPromise.then(function(resp) {
         btxn.alerts = resp.data;
@@ -108,12 +107,12 @@ module BTM {
     };
 
     $scope.deleteBusinessTxn = function(btxn) {
-      if (confirm('Are you sure you want to delete business transaction \"'+btxn.summary.name+'\"?')) {
-        $http.delete('/hawkular/btm/config/businesstxn/full/'+btxn.summary.name).then(function(resp) {
-          console.log('Deleted: '+btxn.summary.name);
+      if (confirm('Are you sure you want to delete business transaction \"'+btxn.name+'\"?')) {
+        $http.delete('/hawkular/btm/config/businesstxn/full/'+btxn.name).then(function(resp) {
+          console.log('Deleted: '+btxn.name);
           $scope.businessTransactions.remove(btxn);
         },function(resp) {
-          console.log("Failed to delete business txn '"+btxn.summary.name+"': "+JSON.stringify(resp));
+          console.log("Failed to delete business txn '"+btxn.name+"': "+JSON.stringify(resp));
         });
       }
     };
@@ -153,14 +152,14 @@ module BTM {
         var btxn = $scope.businessTransactions[i];
         if (btxn.count !== undefined && btxn.count > 0) {
           var record=[ ];
-          record.push(btxn.summary.name);
+          record.push(btxn.name);
           record.push(btxn.count);
           btxndata.push(record);
 
-          if ($scope.txnCountValues.indexOf(btxn.summary.name) !== -1) {
-            removeTxnCountValues.remove(btxn.summary.name);
+          if ($scope.txnCountValues.indexOf(btxn.name) !== -1) {
+            removeTxnCountValues.remove(btxn.name);
           } else {
-            $scope.txnCountValues.add(btxn.summary.name);
+            $scope.txnCountValues.add(btxn.name);
           }
         }
       }
@@ -184,14 +183,14 @@ module BTM {
         var btxn = $scope.businessTransactions[i];
         if (btxn.faultcount !== undefined && btxn.faultcount > 0) {
           var record=[ ];
-          record.push(btxn.summary.name);
+          record.push(btxn.name);
           record.push(btxn.faultcount);
           btxnfaultdata.push(record);
 
-          if ($scope.faultCountValues.indexOf(btxn.summary.name) !== -1) {
-            removeFaultCountValues.remove(btxn.summary.name);
+          if ($scope.faultCountValues.indexOf(btxn.name) !== -1) {
+            removeFaultCountValues.remove(btxn.name);
           } else {
-            $scope.faultCountValues.add(btxn.summary.name);
+            $scope.faultCountValues.add(btxn.name);
           }
         }
       }

--- a/ui/src/main/scripts/plugins/btm/ts/btxndisabled.ts
+++ b/ui/src/main/scripts/plugins/btm/ts/btxndisabled.ts
@@ -25,13 +25,7 @@ module BTM {
 
     $scope.reload = function() {
       $http.get('/hawkular/btm/config/businesstxn/summary').then(function(resp) {
-        $scope.businessTransactions = [];
-        for (var i = 0; i < resp.data.length; i++) {
-          var btxn = {
-            summary: resp.data[i]
-          };
-          $scope.businessTransactions.add(btxn);
-        }
+        $scope.businessTransactions = resp.data;
       },function(resp) {
         console.log("Failed to get business txn summaries: "+JSON.stringify(resp));
       });
@@ -46,12 +40,12 @@ module BTM {
     $scope.reload();
 
     $scope.deleteBusinessTxn = function(btxn) {
-      if (confirm('Are you sure you want to delete business transaction \"'+btxn.summary.name+'\"?')) {
-        $http.delete('/hawkular/btm/config/businesstxn/full/'+btxn.summary.name).then(function(resp) {
-          console.log('Deleted: '+btxn.summary.name);
+      if (confirm('Are you sure you want to delete business transaction \"'+btxn.name+'\"?')) {
+        $http.delete('/hawkular/btm/config/businesstxn/full/'+btxn.name).then(function(resp) {
+          console.log('Deleted: '+btxn.name);
           $scope.businessTransactions.remove(btxn);
         },function(resp) {
-          console.log("Failed to delete business txn '"+btxn.summary.name+"': "+JSON.stringify(resp));
+          console.log("Failed to delete business txn '"+btxn.name+"': "+JSON.stringify(resp));
         });
       }
     };

--- a/ui/src/main/scripts/plugins/btm/ts/btxnignored.ts
+++ b/ui/src/main/scripts/plugins/btm/ts/btxnignored.ts
@@ -25,13 +25,7 @@ module BTM {
 
     $scope.reload = function() {
       $http.get('/hawkular/btm/config/businesstxn/summary').then(function(resp) {
-        $scope.businessTransactions = [];
-        for (var i = 0; i < resp.data.length; i++) {
-          var btxn = {
-            summary: resp.data[i]
-          };
-          $scope.businessTransactions.add(btxn);
-        }
+        $scope.businessTransactions = resp.data;
       },function(resp) {
         console.log("Failed to get business txn summaries: "+JSON.stringify(resp));
       });
@@ -46,12 +40,12 @@ module BTM {
     $scope.reload();
 
     $scope.deleteBusinessTxn = function(btxn) {
-      if (confirm('Are you sure you want to delete business transaction \"'+btxn.summary.name+'\"?')) {
-        $http.delete('/hawkular/btm/config/businesstxn/full/'+btxn.summary.name).then(function(resp) {
-          console.log('Deleted: '+btxn.summary.name);
+      if (confirm('Are you sure you want to delete business transaction \"'+btxn.name+'\"?')) {
+        $http.delete('/hawkular/btm/config/businesstxn/full/'+btxn.name).then(function(resp) {
+          console.log('Deleted: '+btxn.name);
           $scope.businessTransactions.remove(btxn);
         },function(resp) {
-          console.log("Failed to delete business txn '"+btxn.summary.name+"': "+JSON.stringify(resp));
+          console.log("Failed to delete business txn '"+btxn.name+"': "+JSON.stringify(resp));
         });
       }
     };


### PR DESCRIPTION
The hk-url-item CSS class in the console has some remove animation, not
intended to be used in BTM context, replaced the classes -url- by -txn-.

Also fixed the refresh process by having data always available, by only
replacing the data when all of it is gathered.