### PR TITLE
HWKBTM-337 : Fix error loading pie charts

### DIFF
--- a/ui/src/main/scripts/plugins/btm/html/btm.html
+++ b/ui/src/main/scripts/plugins/btm/html/btm.html
@@ -46,13 +46,13 @@
       <div class="card-pf">
         <div class="card-pf-title">Transaction Count</div>
         <div class="card-pf-body">
-          <div id="btxntxncountpiechart" style="height: 250px;" ng-init="reloadTxnCountGraph()"></div>
+          <div id="btxntxncountpiechart" style="height: 250px;"></div>
         </div>
       </div>
       <div class="card-pf">
         <div class="card-pf-title">Fault Count</div>
           <div class="card-pf-body">
-            <div id="btxnfaultcountpiechart" style="height: 250px;" ng-init="reloadFaultCountGraph()"></div>
+            <div id="btxnfaultcountpiechart" style="height: 250px;"></div>
           </div>
       </div>
     </div><!-- .col-md-3 -->

--- a/ui/src/main/scripts/plugins/btm/ts/btm.ts
+++ b/ui/src/main/scripts/plugins/btm/ts/btm.ts
@@ -38,8 +38,13 @@ module BTM {
           $scope.businessTransactions = resp.data;
           $scope.businessTransactions.$resolved = true;
 
-          $scope.reloadTxnCountGraph();
-          $scope.reloadFaultCountGraph();
+          if (!$scope.btxncountpiechart || !$scope.btxnfaultcountpiechart) {
+            $scope.initGraph();
+          } else {
+            $scope.reloadTxnCountGraph();
+            $scope.reloadFaultCountGraph();
+          }
+
         });
       },function(resp) {
         console.log("Failed to get business txn summaries: "+JSON.stringify(resp));
@@ -116,8 +121,7 @@ module BTM {
         $scope.btxncountpiechart = c3.generate({
           bindto: '#btxntxncountpiechart',
           data: {
-            json: [
-            ],
+            columns: [],
             type: 'pie',
             onclick: function(d, i) {
               $location.path('/hawkular-ui/btm/info/' + d.id);
@@ -126,10 +130,9 @@ module BTM {
         });
 
         $scope.btxnfaultcountpiechart = c3.generate({
-          bindto: d3.select('#btxnfaultcountpiechart'),
+          bindto: '#btxnfaultcountpiechart',
           data: {
-            json: [
-            ],
+            columns: [],
             type: 'pie',
             onclick: function(d, i) {
               $location.path('/hawkular-ui/btm/info/' + d.id);


### PR DESCRIPTION
This was due to element not being ready at time of the reload, there was
a race condition between DOM element init and ng-init execution.
In the future we should use some form of C3 charts for angular to avoid
manually refreshing.