### PR TITLE
HWKBTM-362 : Specify default charts Y-scale

### DIFF
--- a/ui/src/main/scripts/plugins/apm/ts/apm.ts
+++ b/ui/src/main/scripts/plugins/apm/ts/apm.ts
@@ -71,6 +71,7 @@ module APM {
         },
         y: {
           label: 'Seconds',
+          default: [0, 10000000000],
           padding: {bottom: 0},
           tick: {
             format: function (y) { return y / 1000000000; }

--- a/ui/src/main/scripts/plugins/btm/ts/btxninfo.ts
+++ b/ui/src/main/scripts/plugins/btm/ts/btxninfo.ts
@@ -85,6 +85,7 @@ module BTM {
         },
         y: {
           label: 'Seconds',
+          default: [0, 10000],
           padding: { bottom: 0 },
           tick: {
             format: function(y) { return y / 1000; }


### PR DESCRIPTION
This sets the default Y scale to be 0-10 when there's no data.