### PR TITLE
HWKBTM-376 Mark EJB component node as 'ignored', to cater for situati…

### DIFF
--- a/api/src/main/java/org/hawkular/btm/api/model/config/instrumentation/IgnoreNode.java
+++ b/api/src/main/java/org/hawkular/btm/api/model/config/instrumentation/IgnoreNode.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.btm.api.model.config.instrumentation;
+
+/**
+ * This type represents the session action for ignoring the current node. Ignoring
+ * a node only implies that if 'ignored' nodes are the only remaining nodes associated
+ * with a business fragment that is being captured, then the fragment will be considered
+ * 'complete' - although the fragment will not be sent until all of these nodes have
+ * been individually popped off the stack.
+ *
+ * NOTE: This is to handle situations where due to async handling of requests, some nodes
+ * are processed before others. A better solution may be required, but for now this prevents
+ * an EJB async invoke, providing a JAX-RS endpoint, from reporting an error as the
+ * JAX-RS consumer ends before the EJB invoke (component) ends. (See HWKBTM-376 for more details).
+ *
+ * @author gbrown
+ */
+public class IgnoreNode extends SessionAction {
+
+}

--- a/api/src/main/java/org/hawkular/btm/api/model/config/instrumentation/InstrumentAction.java
+++ b/api/src/main/java/org/hawkular/btm/api/model/config/instrumentation/InstrumentAction.java
@@ -35,12 +35,12 @@ import io.swagger.annotations.ApiModel;
     @Type(value = SetProperty.class), @Type(value = InitiateCorrelation.class),
     @Type(value = CompleteCorrelation.class), @Type(value = Correlate.class),
     @Type(value = Unlink.class), @Type(value = AssertComplete.class), @Type(value = Suppress.class),
-    @Type(value = ProcessHeaders.class), @Type(value = SetPrincipal.class) })
+    @Type(value = ProcessHeaders.class), @Type(value = SetPrincipal.class), @Type(value = IgnoreNode.class) })
 @ApiModel(subTypes = { InstrumentComponent.class, InstrumentConsumer.class,
         InstrumentProducer.class, FreeFormAction.class, ProcessContent.class,
         SetDetail.class, SetFault.class, SetName.class, SetLevel.class, SetProperty.class, InitiateCorrelation.class,
         CompleteCorrelation.class, Correlate.class, Unlink.class, AssertComplete.class, Suppress.class,
-        ProcessHeaders.class, SetPrincipal.class },
+        ProcessHeaders.class, SetPrincipal.class, IgnoreNode.class },
         discriminator = "type")
 public abstract class InstrumentAction {
 

--- a/client/api/src/main/java/org/hawkular/btm/client/api/SessionManager.java
+++ b/client/api/src/main/java/org/hawkular/btm/client/api/SessionManager.java
@@ -139,6 +139,12 @@ public interface SessionManager {
     void suppress();
 
     /**
+     * This method indicates that the current node can be ignored if handled out of
+     * order.
+     */
+    void ignoreNode();
+
+    /**
      * This method asserts that the current thread of execution is complete. It has no
      * impact on business transaction reporting, but is used as a sanity check to ensure
      * the collection is working correctly.

--- a/client/btxn-collector/src/main/java/org/hawkular/btm/client/collector/DefaultBusinessTransactionCollector.java
+++ b/client/btxn-collector/src/main/java/org/hawkular/btm/client/collector/DefaultBusinessTransactionCollector.java
@@ -1608,6 +1608,18 @@ public class DefaultBusinessTransactionCollector implements BusinessTransactionC
     }
 
     /* (non-Javadoc)
+     * @see org.hawkular.btm.api.client.SessionManager#ignoreNode()
+     */
+    @Override
+    public void ignoreNode() {
+        FragmentBuilder builder = fragmentManager.getFragmentBuilder();
+
+        if (builder != null) {
+            builder.ignoreNode();
+        }
+    }
+
+    /* (non-Javadoc)
      * @see org.hawkular.btm.api.client.SessionManager#assertComplete()
      */
     @Override
@@ -1621,8 +1633,13 @@ public class DefaultBusinessTransactionCollector implements BusinessTransactionC
                 FragmentBuilder builder = fragmentManager.getFragmentBuilder();
 
                 if (!builder.isComplete()) {
-                    log.severe("Business transaction has not completed: "
+                    if (builder.isCompleteExceptIgnoredNodes() && log.isLoggable(Level.FINEST)) {
+                        log.finest("Business transaction fragment only contains 'ignored' nodes: "
                             + fragmentManager.getFragmentBuilder());
+                    } else if (log.isLoggable(Level.FINEST)) {
+                        log.finest("ERROR: Business transaction has not completed: "
+                            + fragmentManager.getFragmentBuilder());
+                    }
                 }
             }
         } catch (Throwable t) {

--- a/client/btxn-collector/src/main/java/org/hawkular/btm/client/collector/internal/FragmentBuilder.java
+++ b/client/btxn-collector/src/main/java/org/hawkular/btm/client/collector/internal/FragmentBuilder.java
@@ -56,6 +56,8 @@ public class FragmentBuilder {
 
     private Map<String, Node> retainedNodes = new HashMap<String, Node>();
 
+    private List<Node> ignoredNodes = new ArrayList<Node>();
+
     private List<String> uncompletedCorrelationIds = new ArrayList<String>();
 
     private boolean suppress = false;
@@ -100,6 +102,34 @@ public class FragmentBuilder {
     public boolean isComplete() {
         synchronized (nodeStack) {
             return nodeStack.isEmpty() && retainedNodes.isEmpty();
+        }
+    }
+
+    /**
+     * This method determines if the fragment is complete
+     * with the exception of ignored nodes.
+     *
+     * @return Whether the fragment is complete with the exception of
+     *              ignored nodes
+     */
+    public boolean isCompleteExceptIgnoredNodes() {
+        synchronized (nodeStack) {
+            if (nodeStack.isEmpty() && retainedNodes.isEmpty()) {
+                return true;
+            } else {
+                // Check that remaining nodes can be ignored
+                for (int i=0; i < nodeStack.size(); i++) {
+                    if (!ignoredNodes.contains(nodeStack.get(i))) {
+                        return false;
+                    }
+                }
+                for (int i=0; i < retainedNodes.size(); i++) {
+                    if (!ignoredNodes.contains(retainedNodes.get(i))) {
+                        return false;
+                    }
+                }
+                return true;
+            }
         }
     }
 
@@ -247,7 +277,7 @@ public class FragmentBuilder {
                         return suppressed;
                     }
                 } else {
-                    // If suppression parent popped, then canel the suppress mode
+                    // If suppression parent popped, then cancel the suppress mode
                     suppress = false;
                 }
             }
@@ -373,6 +403,18 @@ public class FragmentBuilder {
      */
     public boolean isSuppressed() {
         return suppress;
+    }
+
+    /**
+     * This method adds the current node to the list of 'ignored'
+     * nodes. These nodes are irrelant when determining if the business
+     * transaction has completed.
+     */
+    public void ignoreNode() {
+        Node node=getCurrentNode();
+        if (node != null) {
+            ignoredNodes.add(node);
+        }
     }
 
     /**

--- a/client/btxn-collector/src/test/java/org/hawkular/btm/client/collector/internal/FragmentBuilderTest.java
+++ b/client/btxn-collector/src/test/java/org/hawkular/btm/client/collector/internal/FragmentBuilderTest.java
@@ -272,6 +272,30 @@ public class FragmentBuilderTest {
 
         assertNotNull(builder.popNode(Consumer.class, null));
 
+        assertFalse(builder.isComplete());
+
+        assertNotNull(builder.popNode(Component.class, null));
+
+        assertTrue(builder.isComplete());
+    }
+
+    @Test
+    public void testAsyncStackIgnoreNodeNoUri() {
+        FragmentBuilder builder = new FragmentBuilder();
+
+        Consumer consumer = new Consumer();
+        builder.pushNode(consumer);
+
+        Component c1 = new Component();
+        builder.pushNode(c1);
+        builder.ignoreNode();
+
+        assertNotNull(builder.popNode(Consumer.class, null));
+
+        assertFalse(builder.isComplete());
+
+        assertTrue(builder.isCompleteExceptIgnoredNodes());
+
         assertNotNull(builder.popNode(Component.class, null));
 
         assertTrue(builder.isComplete());

--- a/client/btxn-instrumentation/src/main/resources/btmconfig/org/jboss/btm-as-ee.json
+++ b/client/btxn-instrumentation/src/main/resources/btmconfig/org/jboss/btm-as-ee.json
@@ -22,6 +22,8 @@
           "componentTypeExpression": "\"EJB\"",
           "operationExpression": "$2.getName()",
           "uriExpression": "removeAfter(simpleClassName($1),\"$$$\")"
+        },{
+          "type": "IgnoreNode"
         }]
       },{
         "ruleName": "EE Component End",

--- a/client/client-manager/src/main/java/org/hawkular/btm/client/manager/RuleHelper.java
+++ b/client/client-manager/src/main/java/org/hawkular/btm/client/manager/RuleHelper.java
@@ -419,6 +419,17 @@ public class RuleHelper extends Helper implements SessionManager {
     }
 
     /* (non-Javadoc)
+     * @see org.hawkular.btm.client.api.SessionManager#ignoreNode()
+     */
+    @Override
+    public void ignoreNode() {
+        if (log.isLoggable(Level.FINEST)) {
+            log.finest("Ignore node location=[" + getRuleName() + "]");
+        }
+        collector().session().ignoreNode();
+    }
+
+    /* (non-Javadoc)
      * @see org.hawkular.btm.client.api.SessionManager#assertComplete()
      */
     @Override

--- a/client/client-manager/src/main/java/org/hawkular/btm/client/manager/config/IgnoreNodeTransformer.java
+++ b/client/client-manager/src/main/java/org/hawkular/btm/client/manager/config/IgnoreNodeTransformer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.btm.client.manager.config;
+
+import org.hawkular.btm.api.model.config.instrumentation.IgnoreNode;
+import org.hawkular.btm.api.model.config.instrumentation.InstrumentAction;
+
+/**
+ * This class transforms the IgnoreNode action type.
+ *
+ * @author gbrown
+ */
+public class IgnoreNodeTransformer implements InstrumentActionTransformer {
+
+    /* (non-Javadoc)
+     * @see org.hawkular.btm.client.manager.config.InstrumentActionTransformer#getActionType()
+     */
+    @Override
+    public Class<? extends InstrumentAction> getActionType() {
+        return IgnoreNode.class;
+    }
+
+    /* (non-Javadoc)
+     * @see org.hawkular.btm.client.manager.config.InstrumentActionTransformer#convertToRuleAction(
+     *                      org.hawkular.btm.api.model.admin.InstrumentAction)
+     */
+    @Override
+    public String convertToRuleAction(InstrumentAction action) {
+        return "ignoreNode()";
+    }
+
+}

--- a/client/client-manager/src/main/resources/META-INF/services/org.hawkular.btm.client.manager.config.InstrumentActionTransformer
+++ b/client/client-manager/src/main/resources/META-INF/services/org.hawkular.btm.client.manager.config.InstrumentActionTransformer
@@ -1,3 +1,4 @@
+org.hawkular.btm.client.manager.config.IgnoreNodeTransformer
 org.hawkular.btm.client.manager.config.InstrumentComponentTransformer
 org.hawkular.btm.client.manager.config.InstrumentConsumerTransformer
 org.hawkular.btm.client.manager.config.InstrumentProducerTransformer


### PR DESCRIPTION
…on where the EJB impl is also a JAX-RS impl with an async method, as the async (consumer) end occurs before the EJB component node is popped. Currently does not check that the invoked method is async before marking as ignored - this could be an enhancement