### PR TITLE
HWKBTM-365 : Keep pie chart colors when filtering

### DIFF
--- a/ui/src/main/scripts/plugins/btm/html/btxninfo.html
+++ b/ui/src/main/scripts/plugins/btm/html/btxninfo.html
@@ -128,7 +128,7 @@
           Faults
         </div>
         <div class="card-pf-body">
-          <div id="completiontimefaultschart" pf-c3-chart config="ctFaultChartConfig" ng-show="faults.length"></div>
+          <div id="completiontimefaultschart" pf-c3-chart config="ctFaultChartConfig" ng-show="faults.length" get-chart-callback="getFaultsChart"></div>
           <div id="btm-faults-placeholder" class="text-center" ng-hide="faults.length">
             <i class="fa fa-pie-chart hk-no-pie-data"></i>
             <h1> No Data Available </h1>
@@ -150,7 +150,7 @@
           </div>
         </div>
         <div class="card-pf-body">
-          <div id="completiontimepropertychart" pf-c3-chart config="ctPropChartConfig" ng-show="properties.length"></div>
+          <div id="completiontimepropertychart" pf-c3-chart config="ctPropChartConfig" ng-show="properties.length" get-chart-callback="getPropsChart"></div>
           <div id="btm-properties-placeholder" class="text-center" ng-hide="properties.length">
             <i class="fa fa-pie-chart hk-no-pie-data"></i>
             <h1> No Data Available </h1>


### PR DESCRIPTION
When filtering data (by clicking in the pie chart), colors were being
reset and re-used for different values. With this fix, they now keep the
same color as before filtering.