### PR TITLE
HWKBTM-382 : Go to BTx Info on click @ Fault Count

### DIFF
--- a/ui/src/main/scripts/plugins/btm/ts/btm.ts
+++ b/ui/src/main/scripts/plugins/btm/ts/btm.ts
@@ -27,15 +27,17 @@ module BTM {
 
     $scope.businessTransactions = [];
 
+    let redirectToInfo = function(btxn) {
+      $timeout(() => {
+        $location.path('/hawkular-ui/btm/info/' + btxn.id);
+      });
+    };
+
     $scope.countChartConfig = {
       data: {
         type: 'pie',
         columns: $scope.btxnCountData || [],
-        onclick: function(d, i) {
-          $timeout(() => {
-            $location.path('/hawkular-ui/btm/info/' + d.id);
-          });
-        }
+        onclick: redirectToInfo
       }
     };
 
@@ -43,9 +45,7 @@ module BTM {
       data: {
         type: 'pie',
         columns: $scope.btxnFaultData || [],
-        onclick: function(d, i) {
-          $location.path('/hawkular-ui/btm/info/' + d.id);
-        }
+        onclick: redirectToInfo
       }
     };
 


### PR DESCRIPTION
When clicking on Fault Count chart for a specific BTxn, it wasn't
(immediately) leading the user to info page, which only occurred when
a digest cycle happened (could take several seconds). This fixes it by
wrapping it in a $timeout call.

Also took the chance to refactor it to a single function for both charts