### PR TITLE
Improve charts spacing and placeholder

### DIFF
--- a/ui/src/main/scripts/plugins/btm/html/btm.html
+++ b/ui/src/main/scripts/plugins/btm/html/btm.html
@@ -47,7 +47,7 @@
         <div class="card-pf-title">Transaction Count</div>
         <div class="card-pf-body">
           <div id="btxntxncountpiechart" pf-c3-chart config="countChartConfig" ng-show="countChartHasData"></div>
-          <div id="btxntxncountplaceholder" class="text-center" style="height: 250px;" ng-hide="countChartHasData">
+          <div id="btxntxncountplaceholder" class="text-center" style="height: 320px;" ng-hide="countChartHasData">
             <i class="fa fa-pie-chart hk-no-pie-data"></i>
             <h1> No Data Available </h1>
           </div>
@@ -57,7 +57,7 @@
         <div class="card-pf-title">Fault Count</div>
           <div class="card-pf-body">
           <div id="btxnfaultcountpiechart" pf-c3-chart config="faultChartConfig" ng-show="faultChartHasData"></div>
-            <div id="btxnfaultcountplaceholder" class="text-center" style="height: 250px;" ng-hide="faultChartHasData">
+            <div id="btxnfaultcountplaceholder" class="text-center" style="height: 320px;" ng-hide="faultChartHasData">
               <i class="fa fa-pie-chart hk-no-pie-data"></i>
               <h1> No Data Available </h1>
             </div>

--- a/ui/src/main/scripts/plugins/btm/html/btxninfo.html
+++ b/ui/src/main/scripts/plugins/btm/html/btxninfo.html
@@ -120,7 +120,7 @@
     </div>
   </div><!-- .row-cards-pf -->
 
-  <div class="row row-cards-pf">
+  <div class="row row-cards-pf hk-row-cards-flexbox">
 
     <div class="col-md-6 col-sm-12">
       <div class="card-pf">

--- a/ui/src/main/scripts/plugins/btm/less/btm.less
+++ b/ui/src/main/scripts/plugins/btm/less/btm.less
@@ -106,7 +106,7 @@ he .dropdown {
 }
 
 i.hk-no-pie-data {
-  font-size: 13em;
+  font-size: 18em;
   opacity: 0.3;
   margin-top: 10px;
 }


### PR DESCRIPTION
- Make "No data" same height (320px) as when there's a chart with data;
- Use flexbox to keep cards at same height at BTxn Info (when there's a
  section with data and other without);
- Increase placeholder icon size to make it more similar to chart size;