### PR TITLE
HWKBTM-385 : Fix height of chart container element

### DIFF
--- a/ui/src/main/scripts/plugins/apm/html/apm.html
+++ b/ui/src/main/scripts/plugins/apm/html/apm.html
@@ -80,7 +80,7 @@
             </div>
           </form>
 
-          <div id="nodesareachart" pf-c3-chart config="apmChartConfig"></div>
+          <div id="nodesareachart" class="chart-card" pf-c3-chart config="apmChartConfig"></div>
 
         </div>
       </div>

--- a/ui/src/main/scripts/plugins/btm/html/btm.html
+++ b/ui/src/main/scripts/plugins/btm/html/btm.html
@@ -46,7 +46,7 @@
       <div class="card-pf">
         <div class="card-pf-title">Transaction Count</div>
         <div class="card-pf-body">
-          <div id="btxntxncountpiechart" pf-c3-chart config="countChartConfig" ng-show="countChartHasData"></div>
+          <div id="btxntxncountpiechart" class="chart-card" pf-c3-chart config="countChartConfig" ng-show="countChartHasData"></div>
           <div id="btxntxncountplaceholder" class="text-center" style="height: 320px;" ng-hide="countChartHasData">
             <i class="fa fa-pie-chart hk-no-pie-data"></i>
             <h1> No Data Available </h1>
@@ -56,7 +56,7 @@
       <div class="card-pf">
         <div class="card-pf-title">Fault Count</div>
           <div class="card-pf-body">
-          <div id="btxnfaultcountpiechart" pf-c3-chart config="faultChartConfig" ng-show="faultChartHasData"></div>
+          <div id="btxnfaultcountpiechart" class="chart-card" pf-c3-chart config="faultChartConfig" ng-show="faultChartHasData"></div>
             <div id="btxnfaultcountplaceholder" class="text-center" style="height: 320px;" ng-hide="faultChartHasData">
               <i class="fa fa-pie-chart hk-no-pie-data"></i>
               <h1> No Data Available </h1>

--- a/ui/src/main/scripts/plugins/btm/html/btxninfo.html
+++ b/ui/src/main/scripts/plugins/btm/html/btxninfo.html
@@ -113,7 +113,7 @@
 
           </form>
 
-          <div id="completiontimelinechart" pf-c3-chart config="compTimeChartConfig"></div>
+          <div id="completiontimelinechart" class="chart-card" pf-c3-chart config="compTimeChartConfig"></div>
 
         </div>
       </div>
@@ -128,7 +128,7 @@
           Faults
         </div>
         <div class="card-pf-body">
-          <div id="completiontimefaultschart" pf-c3-chart config="ctFaultChartConfig" ng-show="faults.length" get-chart-callback="getFaultsChart"></div>
+          <div id="completiontimefaultschart" class="chart-card" pf-c3-chart config="ctFaultChartConfig" ng-show="faults.length" get-chart-callback="getFaultsChart"></div>
           <div id="btm-faults-placeholder" class="text-center" ng-hide="faults.length">
             <i class="fa fa-pie-chart hk-no-pie-data"></i>
             <h1> No Data Available </h1>
@@ -150,7 +150,7 @@
           </div>
         </div>
         <div class="card-pf-body">
-          <div id="completiontimepropertychart" pf-c3-chart config="ctPropChartConfig" ng-show="properties.length" get-chart-callback="getPropsChart"></div>
+          <div id="completiontimepropertychart" class="chart-card" pf-c3-chart config="ctPropChartConfig" ng-show="properties.length" get-chart-callback="getPropsChart"></div>
           <div id="btm-properties-placeholder" class="text-center" ng-hide="properties.length">
             <i class="fa fa-pie-chart hk-no-pie-data"></i>
             <h1> No Data Available </h1>

--- a/ui/src/main/scripts/plugins/btm/less/btm.less
+++ b/ui/src/main/scripts/plugins/btm/less/btm.less
@@ -101,6 +101,14 @@ he .dropdown {
 
 // Charts
 
+.chart-card {
+  min-height: 320px;
+
+  @media (max-width: @screen-xs-max) {
+    min-height: 240px;
+  }
+}
+
 .form-inline + .c3 {
   margin-top: @grid-gutter-width/2;
 }


### PR DESCRIPTION
The chart container element must have a min-height to keep the chart
from decreasing indefinitely. This adds a 320px min-height (or 240px in
case of "mobile" size) to the container.