### PR TITLE
HWKBTM-374 Instrument RxJava to track asynchronous execution of busin…

### DIFF
--- a/api/src/main/java/org/hawkular/btm/api/model/config/instrumentation/InstrumentRule.java
+++ b/api/src/main/java/org/hawkular/btm/api/model/config/instrumentation/InstrumentRule.java
@@ -68,6 +68,9 @@ public class InstrumentRule {
     @JsonInclude(Include.NON_NULL)
     private String toVersion;
 
+    @JsonInclude(Include.NON_DEFAULT)
+    private boolean compile = true;
+
     /**
      * @return the ruleName
      */
@@ -272,4 +275,19 @@ public class InstrumentRule {
         }
         return true;
     }
+
+    /**
+     * @return the compile
+     */
+    public boolean isCompile() {
+        return compile;
+    }
+
+    /**
+     * @param compile the compile to set
+     */
+    public void setCompile(boolean compile) {
+        this.compile = compile;
+    }
+
 }

--- a/api/src/main/java/org/hawkular/btm/api/model/config/instrumentation/Instrumentation.java
+++ b/api/src/main/java/org/hawkular/btm/api/model/config/instrumentation/Instrumentation.java
@@ -32,6 +32,9 @@ public class Instrumentation {
     @JsonInclude(Include.NON_NULL)
     private String description;
 
+    @JsonInclude(Include.NON_DEFAULT)
+    private boolean compile = true;
+
     @JsonInclude
     private List<InstrumentRule> rules = new ArrayList<InstrumentRule>();
 
@@ -47,6 +50,20 @@ public class Instrumentation {
      */
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    /**
+     * @return the compile
+     */
+    public boolean isCompile() {
+        return compile;
+    }
+
+    /**
+     * @param compile the compile to set
+     */
+    public void setCompile(boolean compile) {
+        this.compile = compile;
     }
 
     /**

--- a/client/btxn-instrumentation/src/main/resources/btmconfig/io/netty/btm-netty.json
+++ b/client/btxn-instrumentation/src/main/resources/btmconfig/io/netty/btm-netty.json
@@ -1,0 +1,41 @@
+{
+  "instrumentation": {
+    "io.netty": {
+      "description": "Netty instrumentation",
+      "rules": [{
+        "ruleName": "Netty WriteTask Init",
+        "notes": [
+          "HWKBTM-388 - is this a candidate for unlink pending completion?"
+        ],
+        "className": "^io.netty.channel.AbstractChannelHandlerContext$AbstractWriteTask",
+        "methodName": "<init>",
+        "parameterTypes": [
+          "*"
+        ],
+        "compile": false,
+        "condition": "isActive()",
+        "location": "ENTRY",
+        "actions": [{
+          "type": "InitiateCorrelation",
+          "idExpression": "\"io.netty-async-\"+hashCode($0)"
+        }]
+      },{
+        "ruleName": "Netty WriteTask Run",
+        "notes": [
+        ],
+        "className": "^io.netty.channel.AbstractChannelHandlerContext$AbstractWriteTask",
+        "methodName": "run",
+        "parameterTypes": [
+          "*"
+        ],
+        "compile": false,
+        "location": "ENTRY",
+        "condition": "isCorrelated(\"io.netty-async-\"+hashCode($0))",
+        "actions": [{
+          "type": "CompleteCorrelation",
+          "idExpression": "\"io.netty-async-\"+hashCode($0)"
+        }]
+      }]
+    }
+  }
+}

--- a/client/btxn-instrumentation/src/main/resources/btmconfig/rx/btm-rxjava.json
+++ b/client/btxn-instrumentation/src/main/resources/btmconfig/rx/btm-rxjava.json
@@ -1,0 +1,84 @@
+{
+  "instrumentation": {
+    "rx.java": {
+      "description": "RxJava instrumentation",
+      "rules": [{
+        "ruleName": "RxJava Create Subscriber",
+        "notes": [
+        ],
+        "className": "rx.observers.Subscribers",
+        "methodName": "create",
+        "parameterTypes": [
+          "*"
+        ],
+        "condition": "isActive()",
+        "location": "EXIT",
+        "actions": [{
+          "type": "InitiateCorrelation",
+          "idExpression": "\"rx.java-async-start-\"+hashCode($!)"
+        }]
+      },{
+        "ruleName": "RxJava Subscriber onNext",
+        "notes": [
+        ],
+        "className": "^rx.Subscriber",
+        "methodName": "onNext",
+        "parameterTypes": [
+          "*"
+        ],
+        "compile": false,
+        "location": "ENTRY",
+        "condition": "isCorrelated(\"rx.java-async-start-\"+hashCode($0))",
+        "actions": [{
+          "type": "CompleteCorrelation",
+          "idExpression": "\"rx.java-async-start-\"+hashCode($0)"
+        },{
+          "type": "InitiateCorrelation",
+          "idExpression": "\"rx.java-async-end-\"+hashCode($0)"
+        }]
+      },{
+        "ruleName": "RxJava Subscriber onCompleted",
+        "notes": [
+          "HWKBTM-388 Previously also had an 'unlink' action but this removed the association ",
+          "with the fragment before the Netty HTTP rule could record the completion of the ",
+          "Producer. So need a 'pending cleanup' state for unlink to enable the completion of ",
+          "nodes, but cause the link between the thread and the fragment to be removed if a new ",
+          "business transaction starts."
+        ],
+        "className": "^rx.Subscriber",
+        "methodName": "onCompleted",
+        "parameterTypes": [
+          "*"
+        ],
+        "compile": false,
+        "location": "ENTRY",
+        "condition": "isCorrelated(\"rx.java-async-end-\"+hashCode($0))",
+        "actions": [{
+          "type": "CompleteCorrelation",
+          "idExpression": "\"rx.java-async-end-\"+hashCode($0)"
+        }]
+      },{
+        "ruleName": "RxJava Subscriber onError",
+        "notes": [
+          "HWKBTM-388 Previously also had an 'unlink' action but this removed the association ",
+          "with the fragment before the Netty HTTP rule could record the completion of the ",
+          "Producer. So need a 'pending cleanup' state for unlink to enable the completion of ",
+          "nodes, but cause the link between the thread and the fragment to be removed if a new ",
+          "business transaction starts."
+        ],
+        "className": "^rx.Subscriber",
+        "methodName": "onError",
+        "parameterTypes": [
+          "*"
+        ],
+        "compile": false,
+        "location": "ENTRY",
+        "condition": "isCorrelated(\"rx.java-async-end-\"+hashCode($0))",
+        "actions": [{
+          "type": "CompleteCorrelation",
+          "idExpression": "\"rx.java-async-end-\"+hashCode($0)"
+        }]
+      }]
+    }
+  }
+}

--- a/client/client-manager/src/main/java/org/hawkular/btm/client/manager/BTMAgent.java
+++ b/client/client-manager/src/main/java/org/hawkular/btm/client/manager/BTMAgent.java
@@ -53,6 +53,5 @@ public class BTMAgent {
 
     protected static void initProperties() {
         System.setProperty("org.jboss.byteman.transform.all", "");
-        System.setProperty("org.jboss.byteman.compileToBytecode", "");
     }
 }

--- a/client/client-manager/src/main/java/org/hawkular/btm/client/manager/config/Transformer.java
+++ b/client/client-manager/src/main/java/org/hawkular/btm/client/manager/config/Transformer.java
@@ -52,6 +52,8 @@ public class Transformer {
     public String transform(String name, Instrumentation types, String version) {
         StringBuilder builder = new StringBuilder();
 
+        builder.append(types.isCompile() ? "COMPILE\r\n" : "NOCOMPILE\r\n");
+
         for (int ruleno=0; ruleno < types.getRules().size(); ruleno++) {
             InstrumentRule rule=types.getRules().get(ruleno);
 
@@ -60,9 +62,7 @@ public class Transformer {
                 continue;
             }
 
-            if (builder.length() > 0) {
-                builder.append("\r\n");
-            }
+            builder.append("\r\n");
 
             builder.append("RULE ");
             builder.append(name);
@@ -112,6 +112,10 @@ public class Transformer {
             builder.append("AT ");
             builder.append(rule.getLocation());
             builder.append("\r\n");
+
+            if (rule.isCompile() != types.isCompile()) {
+                builder.append(rule.isCompile() ? "COMPILE\r\n" : "NOCOMPILE\r\n");
+            }
 
             if (!rule.getBinds().isEmpty()) {
                 builder.append("BIND ");

--- a/client/client-manager/src/test/java/org/hawkular/btm/client/manager/config/TransformerTest.java
+++ b/client/client-manager/src/test/java/org/hawkular/btm/client/manager/config/TransformerTest.java
@@ -76,7 +76,8 @@ public class TransformerTest {
 
         String transformed = transformer.transform("test", in, null);
 
-        String expected = "RULE test(1) " + TEST_RULE + "\r\nCLASS " + TEST_CLASS + "\r\n"
+        String expected = "COMPILE\r\n\r\n"
+                + "RULE test(1) " + TEST_RULE + "\r\nCLASS " + TEST_CLASS + "\r\n"
                 + "METHOD " + TEST_METHOD + "()\r\n"
                 + "HELPER " + RuleHelper.class.getName() + "\r\n"
                 + "AT ENTRY\r\nIF TRUE\r\n"
@@ -106,7 +107,7 @@ public class TransformerTest {
 
         String transformed = transformer.transform("test", in, "1.0.0");
 
-        String expected = "";
+        String expected = "COMPILE\r\n";
 
         assertEquals(expected, transformed);
     }
@@ -131,7 +132,7 @@ public class TransformerTest {
 
         String transformed = transformer.transform("test", in, null);
 
-        String expected = "";
+        String expected = "COMPILE\r\n";
 
         assertEquals(expected, transformed);
     }
@@ -156,7 +157,8 @@ public class TransformerTest {
 
         String transformed = transformer.transform("test", in, "2.0.0");
 
-        String expected = "RULE test(1) " + TEST_RULE + "\r\nCLASS " + TEST_CLASS + "\r\n"
+        String expected = "COMPILE\r\n\r\n"
+                + "RULE test(1) " + TEST_RULE + "\r\nCLASS " + TEST_CLASS + "\r\n"
                 + "METHOD " + TEST_METHOD + "()\r\n"
                 + "HELPER " + RuleHelper.class.getName() + "\r\n"
                 + "AT ENTRY\r\nIF TRUE\r\n"
@@ -186,7 +188,8 @@ public class TransformerTest {
 
         String transformed = transformer.transform("test", in, null);
 
-        String expected = "RULE test(1) " + TEST_RULE + "\r\nCLASS " + TEST_CLASS + "\r\n"
+        String expected = "COMPILE\r\n\r\n"
+                + "RULE test(1) " + TEST_RULE + "\r\nCLASS " + TEST_CLASS + "\r\n"
                 + "METHOD " + TEST_METHOD + "()\r\n"
                 + "HELPER " + RuleHelper.class.getName() + "\r\n"
                 + "AT ENTRY\r\nIF TRUE\r\n"
@@ -216,7 +219,8 @@ public class TransformerTest {
 
         String transformed = transformer.transform("test", in, null);
 
-        String expected = "RULE test(1) " + TEST_RULE + "\r\nCLASS " + TEST_CLASS + "\r\n"
+        String expected = "COMPILE\r\n\r\n"
+                + "RULE test(1) " + TEST_RULE + "\r\nCLASS " + TEST_CLASS + "\r\n"
                 + "METHOD " + TEST_METHOD + "\r\n"
                 + "HELPER " + RuleHelper.class.getName() + "\r\n"
                 + "AT ENTRY\r\nIF TRUE\r\n"
@@ -247,7 +251,8 @@ public class TransformerTest {
 
         String transformed = transformer.transform("test", in, null);
 
-        String expected = "RULE test(1) " + TEST_RULE + "\r\nCLASS " + TEST_CLASS + "\r\n"
+        String expected = "COMPILE\r\n\r\n"
+                + "RULE test(1) " + TEST_RULE + "\r\nCLASS " + TEST_CLASS + "\r\n"
                 + "METHOD " + TEST_METHOD + "(" + TEST_PARAM1 + "," + TEST_PARAM2 + ")\r\n"
                 + "HELPER " + RuleHelper.class.getName() + "\r\n"
                 + "AT ENTRY\r\nIF TRUE\r\n"
@@ -279,7 +284,8 @@ public class TransformerTest {
 
         String transformed = transformer.transform("test", in, null);
 
-        String expected = "RULE test(1) " + TEST_RULE + "\r\nCLASS " + TEST_CLASS + "\r\n"
+        String expected = "COMPILE\r\n\r\n"
+                + "RULE test(1) " + TEST_RULE + "\r\nCLASS " + TEST_CLASS + "\r\n"
                 + "METHOD " + TEST_METHOD + "(" + TEST_PARAM1 + "," + TEST_PARAM2 + ")\r\n"
                 + "HELPER " + RuleHelper.class.getName() + "\r\n"
                 + "AT EXIT\r\nIF "
@@ -312,7 +318,8 @@ public class TransformerTest {
 
         String transformed = transformer.transform("test", in, null);
 
-        String expected = "RULE test(1) " + TEST_RULE + "\r\nCLASS " + TEST_CLASS + "\r\n"
+        String expected = "COMPILE\r\n\r\n"
+                + "RULE test(1) " + TEST_RULE + "\r\nCLASS " + TEST_CLASS + "\r\n"
                 + "METHOD " + TEST_METHOD + "(" + TEST_PARAM1 + "," + TEST_PARAM2 + ")\r\n"
                 + "HELPER " + RuleHelper.class.getName() + "\r\n"
                 + "AT EXCEPTION EXIT\r\nIF "
@@ -350,7 +357,8 @@ public class TransformerTest {
 
         String transformed = transformer.transform("test", in, null);
 
-        String expected = "RULE test(1) " + TEST_RULE + "\r\nCLASS " + TEST_CLASS + "\r\n"
+        String expected = "COMPILE\r\n\r\n"
+                + "RULE test(1) " + TEST_RULE + "\r\nCLASS " + TEST_CLASS + "\r\n"
                 + "METHOD " + TEST_METHOD + "(" + TEST_PARAM1 + "," + TEST_PARAM2 + ")\r\n"
                 + "HELPER TestHelper\r\n"
                 + "AT ENTRY\r\nIF "
@@ -395,7 +403,8 @@ public class TransformerTest {
 
         String transformed = transformer.transform("test", in, null);
 
-        String expected = "RULE test(1) " + TEST_RULE + "\r\nCLASS " + TEST_CLASS + "\r\n"
+        String expected = "COMPILE\r\n\r\n"
+                + "RULE test(1) " + TEST_RULE + "\r\nCLASS " + TEST_CLASS + "\r\n"
                 + "METHOD " + TEST_METHOD + "(" + TEST_PARAM1 + "," + TEST_PARAM2 + ")\r\n"
                 + "HELPER " + RuleHelper.class.getName() + "\r\n"
                 + "AT ENTRY\r\n"
@@ -408,4 +417,103 @@ public class TransformerTest {
         assertEquals(expected, transformed);
     }
 
+    @Test
+    public void testTransformNoCompileScript() {
+        InstrumentRule ir = new InstrumentRule();
+        FreeFormAction im = new FreeFormAction();
+
+        ir.setRuleName(TEST_RULE);
+        ir.setClassName(TEST_CLASS);
+        ir.setMethodName(TEST_METHOD);
+        ir.setLocation("ENTRY");
+        ir.getActions().add(im);
+        im.setAction("Action1");
+        ir.setCompile(false);
+
+        Instrumentation in = new Instrumentation();
+        in.setCompile(false);
+        in.getRules().add(ir);
+
+        Transformer transformer = new Transformer();
+
+        String transformed = transformer.transform("test", in, null);
+
+        String expected = "NOCOMPILE\r\n\r\n"
+                + "RULE test(1) " + TEST_RULE + "\r\nCLASS " + TEST_CLASS + "\r\n"
+                + "METHOD " + TEST_METHOD + "()\r\n"
+                + "HELPER " + RuleHelper.class.getName() + "\r\n"
+                + "AT ENTRY\r\nIF TRUE\r\n"
+                + "DO\r\n  " + im.getAction() + "\r\n"
+                + "ENDRULE\r\n\r\n";
+
+        assertEquals(expected, transformed);
+    }
+
+    @Test
+    public void testTransformCompileScriptNoCompileRule() {
+        InstrumentRule ir = new InstrumentRule();
+        FreeFormAction im = new FreeFormAction();
+
+        ir.setRuleName(TEST_RULE);
+        ir.setClassName(TEST_CLASS);
+        ir.setMethodName(TEST_METHOD);
+        ir.setLocation("ENTRY");
+        ir.getActions().add(im);
+        im.setAction("Action1");
+        ir.setCompile(false);
+
+        Instrumentation in = new Instrumentation();
+        in.setCompile(true);
+        in.getRules().add(ir);
+
+        Transformer transformer = new Transformer();
+
+        String transformed = transformer.transform("test", in, null);
+
+        String expected = "COMPILE\r\n\r\n"
+                + "RULE test(1) " + TEST_RULE + "\r\nCLASS " + TEST_CLASS + "\r\n"
+                + "METHOD " + TEST_METHOD + "()\r\n"
+                + "HELPER " + RuleHelper.class.getName() + "\r\n"
+                + "AT ENTRY\r\n"
+                + "NOCOMPILE\r\n"
+                + "IF TRUE\r\n"
+                + "DO\r\n  " + im.getAction() + "\r\n"
+                + "ENDRULE\r\n\r\n";
+
+        assertEquals(expected, transformed);
+    }
+
+    @Test
+    public void testTransformNoCompileScriptCompileRule() {
+        InstrumentRule ir = new InstrumentRule();
+        FreeFormAction im = new FreeFormAction();
+
+        ir.setRuleName(TEST_RULE);
+        ir.setClassName(TEST_CLASS);
+        ir.setMethodName(TEST_METHOD);
+        ir.setLocation("ENTRY");
+        ir.getActions().add(im);
+        im.setAction("Action1");
+        ir.setCompile(true);
+
+        Instrumentation in = new Instrumentation();
+        in.setCompile(false);
+        in.getRules().add(ir);
+
+        Transformer transformer = new Transformer();
+
+        String transformed = transformer.transform("test", in, null);
+
+        String expected = "NOCOMPILE\r\n\r\n"
+                + "RULE test(1) " + TEST_RULE + "\r\nCLASS " + TEST_CLASS + "\r\n"
+                + "METHOD " + TEST_METHOD + "()\r\n"
+                + "HELPER " + RuleHelper.class.getName() + "\r\n"
+                + "AT ENTRY\r\n"
+                + "COMPILE\r\n"
+                + "IF TRUE\r\n"
+                + "DO\r\n  " + im.getAction() + "\r\n"
+                + "ENDRULE\r\n\r\n";
+
+        assertEquals(expected, transformed);
+    }
 }

--- a/client/config-service-rest-client/src/main/java/org/hawkular/btm/config/service/rest/client/ConfigurationServiceRESTClient.java
+++ b/client/config-service-rest-client/src/main/java/org/hawkular/btm/config/service/rest/client/ConfigurationServiceRESTClient.java
@@ -190,9 +190,6 @@ public class ConfigurationServiceRESTClient implements ConfigurationService {
             is.close();
 
             if (connection.getResponseCode() == 200) {
-                if (log.isLoggable(Level.FINEST)) {
-                    log.finest("Returned json=[" + resp.toString() + "]");
-                }
                 try {
                     return mapper.readValue(resp.toString(), CollectorConfiguration.class);
                 } catch (Throwable t) {

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
     <version.org.eclipse.jetty>8.1.15.v20140411</version.org.eclipse.jetty>
     <version.org.elasticsearch>1.7.1</version.org.elasticsearch>
     <version.org.hawkular.accounts>2.0.22.Final</version.org.hawkular.accounts>
-    <version.org.jboss.byteman>3.0.2</version.org.jboss.byteman>
+    <version.org.jboss.byteman>3.0.4</version.org.jboss.byteman>
     <version.org.mvel>2.2.6.Final</version.org.mvel>
     <version.org.slf4j>1.7.5</version.org.slf4j> <!-- Align with version used by camel -->
     <version.org.tuckey>4.0.3</version.org.tuckey>


### PR DESCRIPTION
…ess transactions. Required update to byteman (3.0.4) to include support for NOCOMPILE/COMPILE directives, as some anonymous inner classes were failing the verifier, so had to be interpreted (see BYTEMAN-319). Correlation now exists with the Producer thread, but it is not unlinked, so would remain associated with the fragment until it was published - so there is potential for that thread being used in the meantime and its activities incorrectly being associated with the previous fragment - this issue will be addressed in issue 388, and there is also potential for multiple concurrent outbound interactions to be performed which would need to be monitored in separate fragments, which is discussed in issue 386. Finally, also had to add some Netty rules to capture scheduling of a 'write task' when performing the REST call.