### PR TITLE
HWKBTM-390 Use the 'operation' field, currently only associated with …

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -7,21 +7,29 @@ image::https://travis-ci.org/hawkular/hawkular-btm.svg?branch=master[Build Statu
 endif::[]
 
 [.lead]
-*Hawkular BTM* is the Business Transaction Management module for Hawkular.
+*Hawkular BTM* is the Business Transaction Management (BTM) and Application Performance
+Management (APM) module for Hawkular.
 
 The project will provide the capabilities to monitor the flow of a business transaction
-instance across servers, tiers, on-premises and in the cloud.
+instance across servers, tiers, on-premises and in the cloud. It will also enable detailed
+performance analysis to be performed of the individual components that make up an
+application.
 
 == Build
 
 To build the project, run:
 
 ```shell
-mvn clean install [ -Ptests ]
+mvn clean install [ -Ptests,vertx,wildfly ]
 ```
 
 The optional 'tests' profile will automatically run integration tests within a WildFly instance
 configured with Hawkular Bus and BTM.
+
+The optional 'vertx' profile provides integration tests running in a vertx environment.
+
+The optional 'wildfly' profile provides integration tests against the Hawkular BTM REST APIs
+running in a WildFly server.
 
 The distribution (a preconfigured version of WildFly with all necessary Hawkular components) can be
 found here: _dist/target/hawkular-btm-dist-<version>.zip_.

--- a/api/src/main/java/org/hawkular/btm/api/model/analytics/CommunicationSummaryStatistics.java
+++ b/api/src/main/java/org/hawkular/btm/api/model/analytics/CommunicationSummaryStatistics.java
@@ -27,7 +27,7 @@ import java.util.Map;
  */
 public class CommunicationSummaryStatistics {
 
-    private String uri;
+    private String id;
 
     private long minimumDuration;
 
@@ -40,17 +40,17 @@ public class CommunicationSummaryStatistics {
     private Map<String, ConnectionStatistics> outbound = new HashMap<String, ConnectionStatistics>();
 
     /**
-     * @return the uri
+     * @return the id
      */
-    public String getUri() {
-        return uri;
+    public String getId() {
+        return id;
     }
 
     /**
-     * @param uri the uri to set
+     * @param id the id to set
      */
-    public void setUri(String uri) {
-        this.uri = uri;
+    public void setId(String id) {
+        this.id = id;
     }
 
     /**
@@ -128,7 +128,7 @@ public class CommunicationSummaryStatistics {
      */
     @Override
     public String toString() {
-        return "CommunicationSummaryStatistics [uri=" + uri + ", minimumDuration=" + minimumDuration
+        return "CommunicationSummaryStatistics [id=" + id + ", minimumDuration=" + minimumDuration
                 + ", averageDuration=" + averageDuration + ", maximumDuration=" + maximumDuration + ", count=" + count
                 + ", outbound=" + outbound + "]";
     }

--- a/api/src/main/java/org/hawkular/btm/api/model/btxn/Component.java
+++ b/api/src/main/java/org/hawkular/btm/api/model/btxn/Component.java
@@ -32,9 +32,6 @@ public class Component extends InteractionNode {
     @JsonInclude
     private String componentType;
 
-    @JsonInclude
-    private String operation;
-
     public Component() {
         super(NodeType.Component);
     }
@@ -58,20 +55,6 @@ public class Component extends InteractionNode {
         this.componentType = componentType;
     }
 
-    /**
-     * @return the operation
-     */
-    public String getOperation() {
-        return operation;
-    }
-
-    /**
-     * @param operation the operation to set
-     */
-    public void setOperation(String operation) {
-        this.operation = operation;
-    }
-
     /* (non-Javadoc)
      * @see java.lang.Object#hashCode()
      */
@@ -80,7 +63,6 @@ public class Component extends InteractionNode {
         final int prime = 31;
         int result = super.hashCode();
         result = prime * result + ((componentType == null) ? 0 : componentType.hashCode());
-        result = prime * result + ((operation == null) ? 0 : operation.hashCode());
         return result;
     }
 
@@ -106,13 +88,6 @@ public class Component extends InteractionNode {
         } else if (!componentType.equals(other.componentType)) {
             return false;
         }
-        if (operation == null) {
-            if (other.operation != null) {
-                return false;
-            }
-        } else if (!operation.equals(other.operation)) {
-            return false;
-        }
         return true;
     }
 
@@ -121,9 +96,12 @@ public class Component extends InteractionNode {
      */
     @Override
     public String toString() {
-        return "Component [componentType=" + componentType + ", operation=" + operation + ", getNodes()=" + getNodes()
-                + ", getUri()=" + getUri() + ", getBaseTime()=" + getBaseTime() + ", getDuration()=" + getDuration()
-                + ", getDetails()=" + getDetails() + ", getCorrelationIds()=" + getCorrelationIds() + "]";
+        return "Component [componentType=" + componentType + ", getOperation()=" + getOperation() + ", getIn()="
+                + getIn() + ", getOut()=" + getOut() + ", getNodes()=" + getNodes() + ", getBaseTime()="
+                + getBaseTime() + ", getDuration()=" + getDuration() + ", getFault()=" + getFault()
+                + ", getFaultDescription()=" + getFaultDescription() + ", getDetails()=" + getDetails()
+                + ", getCorrelationIds()=" + getCorrelationIds() + ", getIssues()=" + getIssues() + "]";
     }
+
 
 }

--- a/api/src/main/java/org/hawkular/btm/api/model/btxn/Consumer.java
+++ b/api/src/main/java/org/hawkular/btm/api/model/btxn/Consumer.java
@@ -97,10 +97,12 @@ public class Consumer extends InteractionNode {
      */
     @Override
     public String toString() {
-        return "Consumer [endpointType=" + endpointType + ", getUri()=" + getUri() + ", getIn()=" + getIn()
-                + ", getOut()=" + getOut() + ", getNodes()=" + getNodes() + ", getBaseTime()="
-                + getBaseTime() + ", getDuration()=" + getDuration() + ", getDetails()=" + getDetails()
-                + ", getCorrelationIds()=" + getCorrelationIds() + "]";
+        return "Consumer [endpointType=" + endpointType + ", getOperation()=" + getOperation() + ", getIn()="
+                + getIn() + ", getOut()=" + getOut() + ", getNodes()=" + getNodes() + ", getType()=" + getType()
+                + ", getUri()=" + getUri() + ", getBaseTime()=" + getBaseTime() + ", getDuration()=" + getDuration()
+                + ", getFault()=" + getFault() + ", getFaultDescription()=" + getFaultDescription()
+                + ", getDetails()=" + getDetails() + ", getCorrelationIds()=" + getCorrelationIds() + ", getIssues()="
+                + getIssues() + "]";
     }
 
 }

--- a/api/src/main/java/org/hawkular/btm/api/model/btxn/InteractionNode.java
+++ b/api/src/main/java/org/hawkular/btm/api/model/btxn/InteractionNode.java
@@ -116,30 +116,23 @@ public abstract class InteractionNode extends ContainerNode {
      */
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) {
+        if (this == obj)
             return true;
-        }
-        if (!super.equals(obj)) {
+        if (!super.equals(obj))
             return false;
-        }
-        if (getClass() != obj.getClass()) {
+        if (getClass() != obj.getClass())
             return false;
-        }
         InteractionNode other = (InteractionNode) obj;
         if (in == null) {
-            if (other.in != null) {
+            if (other.in != null)
                 return false;
-            }
-        } else if (!in.equals(other.in)) {
+        } else if (!in.equals(other.in))
             return false;
-        }
         if (out == null) {
-            if (other.out != null) {
+            if (other.out != null)
                 return false;
-            }
-        } else if (!out.equals(other.out)) {
+        } else if (!out.equals(other.out))
             return false;
-        }
         return true;
     }
 

--- a/api/src/main/java/org/hawkular/btm/api/model/btxn/Node.java
+++ b/api/src/main/java/org/hawkular/btm/api/model/btxn/Node.java
@@ -52,6 +52,9 @@ public abstract class Node {
     private String uri;
 
     @JsonInclude
+    private String operation;
+
+    @JsonInclude
     private long baseTime = 0;
 
     @JsonInclude
@@ -129,6 +132,20 @@ public abstract class Node {
     public Node setUri(String uri) {
         this.uri = uri;
         return this;
+    }
+
+    /**
+     * @return the operation
+     */
+    public String getOperation() {
+        return operation;
+    }
+
+    /**
+     * @param operation the operation to set
+     */
+    public void setOperation(String operation) {
+        this.operation = operation;
     }
 
     /**
@@ -387,11 +404,14 @@ public abstract class Node {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
+        result = prime * result + (int) (baseTime ^ (baseTime >>> 32));
         result = prime * result + ((correlationIds == null) ? 0 : correlationIds.hashCode());
         result = prime * result + ((details == null) ? 0 : details.hashCode());
         result = prime * result + (int) (duration ^ (duration >>> 32));
         result = prime * result + ((fault == null) ? 0 : fault.hashCode());
-        result = prime * result + (int) (baseTime ^ (baseTime >>> 32));
+        result = prime * result + ((faultDescription == null) ? 0 : faultDescription.hashCode());
+        result = prime * result + ((issues == null) ? 0 : issues.hashCode());
+        result = prime * result + ((operation == null) ? 0 : operation.hashCode());
         result = prime * result + ((type == null) ? 0 : type.hashCode());
         result = prime * result + ((uri == null) ? 0 : uri.hashCode());
         return result;
@@ -409,6 +429,8 @@ public abstract class Node {
         if (getClass() != obj.getClass())
             return false;
         Node other = (Node) obj;
+        if (baseTime != other.baseTime)
+            return false;
         if (correlationIds == null) {
             if (other.correlationIds != null)
                 return false;
@@ -426,7 +448,20 @@ public abstract class Node {
                 return false;
         } else if (!fault.equals(other.fault))
             return false;
-        if (baseTime != other.baseTime)
+        if (faultDescription == null) {
+            if (other.faultDescription != null)
+                return false;
+        } else if (!faultDescription.equals(other.faultDescription))
+            return false;
+        if (issues == null) {
+            if (other.issues != null)
+                return false;
+        } else if (!issues.equals(other.issues))
+            return false;
+        if (operation == null) {
+            if (other.operation != null)
+                return false;
+        } else if (!operation.equals(other.operation))
             return false;
         if (type != other.type)
             return false;

--- a/api/src/main/java/org/hawkular/btm/api/model/btxn/Producer.java
+++ b/api/src/main/java/org/hawkular/btm/api/model/btxn/Producer.java
@@ -97,10 +97,12 @@ public class Producer extends InteractionNode {
      */
     @Override
     public String toString() {
-        return "Producer [endpointType=" + endpointType + ", getUri()=" + getUri() + ", getIn()=" + getIn()
-                + ", getOut()=" + getOut() + ", getNodes()=" + getNodes() + ", getBaseTime()="
-                + getBaseTime() + ", getDuration()=" + getDuration() + ", getDetails()=" + getDetails()
-                + ", getCorrelationIds()=" + getCorrelationIds() + "]";
+        return "Producer [endpointType=" + endpointType + ", getOperation()=" + getOperation() + ", getIn()="
+                + getIn() + ", getOut()=" + getOut() + ", getNodes()=" + getNodes() + ", getType()=" + getType()
+                + ", getUri()=" + getUri() + ", getBaseTime()=" + getBaseTime() + ", getDuration()=" + getDuration()
+                + ", getFault()=" + getFault() + ", getFaultDescription()=" + getFaultDescription()
+                + ", getDetails()=" + getDetails() + ", getCorrelationIds()=" + getCorrelationIds() + ", getIssues()="
+                + getIssues() + "]";
     }
 
 }

--- a/api/src/main/java/org/hawkular/btm/api/model/config/instrumentation/InstrumentConsumer.java
+++ b/api/src/main/java/org/hawkular/btm/api/model/config/instrumentation/InstrumentConsumer.java
@@ -28,6 +28,9 @@ public class InstrumentConsumer extends CollectorAction {
     @JsonInclude
     private String endpointTypeExpression;
 
+    @JsonInclude
+    private String operationExpression;
+
     /**
      * @return the endpointTypeExpression
      */
@@ -40,6 +43,20 @@ public class InstrumentConsumer extends CollectorAction {
      */
     public void setEndpointTypeExpression(String endpointTypeExpression) {
         this.endpointTypeExpression = endpointTypeExpression;
+    }
+
+    /**
+     * @return the operationExpression
+     */
+    public String getOperationExpression() {
+        return operationExpression;
+    }
+
+    /**
+     * @param operationExpression the operationExpression to set
+     */
+    public void setOperationExpression(String operationExpression) {
+        this.operationExpression = operationExpression;
     }
 
 }

--- a/api/src/main/java/org/hawkular/btm/api/model/config/instrumentation/InstrumentProducer.java
+++ b/api/src/main/java/org/hawkular/btm/api/model/config/instrumentation/InstrumentProducer.java
@@ -28,6 +28,9 @@ public class InstrumentProducer extends CollectorAction {
     @JsonInclude
     private String endpointTypeExpression;
 
+    @JsonInclude
+    private String operationExpression;
+
     /**
      * @return the endpointTypeExpression
      */
@@ -40,6 +43,20 @@ public class InstrumentProducer extends CollectorAction {
      */
     public void setEndpointTypeExpression(String endpointTypeExpression) {
         this.endpointTypeExpression = endpointTypeExpression;
+    }
+
+    /**
+     * @return the operationExpression
+     */
+    public String getOperationExpression() {
+        return operationExpression;
+    }
+
+    /**
+     * @param operationExpression the operationExpression to set
+     */
+    public void setOperationExpression(String operationExpression) {
+        this.operationExpression = operationExpression;
     }
 
 }

--- a/api/src/main/java/org/hawkular/btm/api/model/events/CommunicationDetails.java
+++ b/api/src/main/java/org/hawkular/btm/api/model/events/CommunicationDetails.java
@@ -42,9 +42,9 @@ public class CommunicationDetails implements Externalizable {
 
     private String businessTransaction;
 
-    private String uri;
+    private String source;
 
-    private String originUri;
+    private String target;
 
     private boolean multiConsumer = false;
 
@@ -105,31 +105,31 @@ public class CommunicationDetails implements Externalizable {
     }
 
     /**
-     * @return the uri
+     * @return the source
      */
-    public String getUri() {
-        return uri;
+    public String getSource() {
+        return source;
     }
 
     /**
-     * @param uri the uri to set
+     * @param source the source to set
      */
-    public void setUri(String uri) {
-        this.uri = uri;
+    public void setSource(String source) {
+        this.source = source;
     }
 
     /**
-     * @return the originUri
+     * @return the target
      */
-    public String getOriginUri() {
-        return originUri;
+    public String getTarget() {
+        return target;
     }
 
     /**
-     * @param originUri the originUri to set
+     * @param target the target to set
      */
-    public void setOriginUri(String originUri) {
-        this.originUri = originUri;
+    public void setTarget(String target) {
+        this.target = target;
     }
 
     /**
@@ -354,6 +354,39 @@ public class CommunicationDetails implements Externalizable {
         this.outbound = outbound;
     }
 
+    /**
+     * This method converts the supplied URI and optional operation
+     * into an 'origin' descriptor.
+     *
+     * @param uri The URI
+     * @param operation The optional operation
+     * @return The origin descriptor
+     */
+    public static String encodeUriAndOperation(String uri, String operation) {
+        StringBuffer buf=new StringBuffer(uri);
+        if (operation != null && operation.trim().length() > 0) {
+            buf.append('[');
+            buf.append(operation);
+            buf.append(']');
+        }
+        return buf.toString();
+    }
+
+    /* (non-Javadoc)
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "CommunicationDetails [id=" + id + ", businessTransaction=" + businessTransaction + ", source="
+                + source + ", target=" + target + ", multiConsumer=" + multiConsumer + ", timestamp=" + timestamp
+                + ", latency=" + latency + ", consumerDuration=" + consumerDuration + ", producerDuration="
+                + producerDuration + ", timestampOffset=" + timestampOffset + ", sourceFragmentId=" + sourceFragmentId
+                + ", sourceHostName=" + sourceHostName + ", sourceHostAddress=" + sourceHostAddress
+                + ", targetFragmentId=" + targetFragmentId + ", targetHostName=" + targetHostName
+                + ", targetHostAddress=" + targetHostAddress + ", targetFragmentDuration=" + targetFragmentDuration
+                + ", properties=" + properties + ", outbound=" + outbound + "]";
+    }
+
     /* (non-Javadoc)
      * @see java.lang.Object#hashCode()
      */
@@ -366,20 +399,20 @@ public class CommunicationDetails implements Externalizable {
         result = prime * result + ((id == null) ? 0 : id.hashCode());
         result = prime * result + (int) (latency ^ (latency >>> 32));
         result = prime * result + (multiConsumer ? 1231 : 1237);
-        result = prime * result + ((originUri == null) ? 0 : originUri.hashCode());
         result = prime * result + ((outbound == null) ? 0 : outbound.hashCode());
         result = prime * result + (int) (producerDuration ^ (producerDuration >>> 32));
         result = prime * result + ((properties == null) ? 0 : properties.hashCode());
+        result = prime * result + ((source == null) ? 0 : source.hashCode());
         result = prime * result + ((sourceFragmentId == null) ? 0 : sourceFragmentId.hashCode());
         result = prime * result + ((sourceHostAddress == null) ? 0 : sourceHostAddress.hashCode());
         result = prime * result + ((sourceHostName == null) ? 0 : sourceHostName.hashCode());
+        result = prime * result + ((target == null) ? 0 : target.hashCode());
         result = prime * result + (int) (targetFragmentDuration ^ (targetFragmentDuration >>> 32));
         result = prime * result + ((targetFragmentId == null) ? 0 : targetFragmentId.hashCode());
         result = prime * result + ((targetHostAddress == null) ? 0 : targetHostAddress.hashCode());
         result = prime * result + ((targetHostName == null) ? 0 : targetHostName.hashCode());
         result = prime * result + (int) (timestamp ^ (timestamp >>> 32));
         result = prime * result + (int) (timestampOffset ^ (timestampOffset >>> 32));
-        result = prime * result + ((uri == null) ? 0 : uri.hashCode());
         return result;
     }
 
@@ -388,137 +421,88 @@ public class CommunicationDetails implements Externalizable {
      */
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) {
+        if (this == obj)
             return true;
-        }
-        if (obj == null) {
+        if (obj == null)
             return false;
-        }
-        if (getClass() != obj.getClass()) {
+        if (getClass() != obj.getClass())
             return false;
-        }
         CommunicationDetails other = (CommunicationDetails) obj;
         if (businessTransaction == null) {
-            if (other.businessTransaction != null) {
+            if (other.businessTransaction != null)
                 return false;
-            }
-        } else if (!businessTransaction.equals(other.businessTransaction)) {
+        } else if (!businessTransaction.equals(other.businessTransaction))
             return false;
-        }
-        if (consumerDuration != other.consumerDuration) {
+        if (consumerDuration != other.consumerDuration)
             return false;
-        }
         if (id == null) {
-            if (other.id != null) {
+            if (other.id != null)
                 return false;
-            }
-        } else if (!id.equals(other.id)) {
+        } else if (!id.equals(other.id))
             return false;
-        }
-        if (latency != other.latency) {
+        if (latency != other.latency)
             return false;
-        }
-        if (multiConsumer != other.multiConsumer) {
+        if (multiConsumer != other.multiConsumer)
             return false;
-        }
-        if (originUri == null) {
-            if (other.originUri != null) {
-                return false;
-            }
-        } else if (!originUri.equals(other.originUri)) {
-            return false;
-        }
         if (outbound == null) {
-            if (other.outbound != null) {
+            if (other.outbound != null)
                 return false;
-            }
-        } else if (!outbound.equals(other.outbound)) {
+        } else if (!outbound.equals(other.outbound))
             return false;
-        }
-        if (producerDuration != other.producerDuration) {
+        if (producerDuration != other.producerDuration)
             return false;
-        }
         if (properties == null) {
-            if (other.properties != null) {
+            if (other.properties != null)
                 return false;
-            }
-        } else if (!properties.equals(other.properties)) {
+        } else if (!properties.equals(other.properties))
             return false;
-        }
+        if (source == null) {
+            if (other.source != null)
+                return false;
+        } else if (!source.equals(other.source))
+            return false;
         if (sourceFragmentId == null) {
-            if (other.sourceFragmentId != null) {
+            if (other.sourceFragmentId != null)
                 return false;
-            }
-        } else if (!sourceFragmentId.equals(other.sourceFragmentId)) {
+        } else if (!sourceFragmentId.equals(other.sourceFragmentId))
             return false;
-        }
         if (sourceHostAddress == null) {
-            if (other.sourceHostAddress != null) {
+            if (other.sourceHostAddress != null)
                 return false;
-            }
-        } else if (!sourceHostAddress.equals(other.sourceHostAddress)) {
+        } else if (!sourceHostAddress.equals(other.sourceHostAddress))
             return false;
-        }
         if (sourceHostName == null) {
-            if (other.sourceHostName != null) {
+            if (other.sourceHostName != null)
                 return false;
-            }
-        } else if (!sourceHostName.equals(other.sourceHostName)) {
+        } else if (!sourceHostName.equals(other.sourceHostName))
             return false;
-        }
-        if (targetFragmentDuration != other.targetFragmentDuration) {
+        if (target == null) {
+            if (other.target != null)
+                return false;
+        } else if (!target.equals(other.target))
             return false;
-        }
+        if (targetFragmentDuration != other.targetFragmentDuration)
+            return false;
         if (targetFragmentId == null) {
-            if (other.targetFragmentId != null) {
+            if (other.targetFragmentId != null)
                 return false;
-            }
-        } else if (!targetFragmentId.equals(other.targetFragmentId)) {
+        } else if (!targetFragmentId.equals(other.targetFragmentId))
             return false;
-        }
         if (targetHostAddress == null) {
-            if (other.targetHostAddress != null) {
+            if (other.targetHostAddress != null)
                 return false;
-            }
-        } else if (!targetHostAddress.equals(other.targetHostAddress)) {
+        } else if (!targetHostAddress.equals(other.targetHostAddress))
             return false;
-        }
         if (targetHostName == null) {
-            if (other.targetHostName != null) {
+            if (other.targetHostName != null)
                 return false;
-            }
-        } else if (!targetHostName.equals(other.targetHostName)) {
+        } else if (!targetHostName.equals(other.targetHostName))
             return false;
-        }
-        if (timestamp != other.timestamp) {
+        if (timestamp != other.timestamp)
             return false;
-        }
-        if (timestampOffset != other.timestampOffset) {
+        if (timestampOffset != other.timestampOffset)
             return false;
-        }
-        if (uri == null) {
-            if (other.uri != null) {
-                return false;
-            }
-        } else if (!uri.equals(other.uri)) {
-            return false;
-        }
         return true;
-    }
-
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
-    @Override
-    public String toString() {
-        return "CommunicationDetails [id=" + id + ", businessTransaction=" + businessTransaction + ", uri=" + uri
-                + ", originUri=" + originUri + ", multiConsumer=" + multiConsumer + ", timestamp=" + timestamp
-                + ", latency=" + latency + ", consumerDuration=" + consumerDuration + ", producerDuration="
-                + producerDuration + ", timestampOffset=" + timestampOffset + ", sourceFragmentId=" + sourceFragmentId
-                + ", sourceHostName=" + sourceHostName + ", sourceHostAddress=" + sourceHostAddress
-                + ", targetFragmentId=" + targetFragmentId + ", targetHostName=" + targetHostName
-                + ", targetHostAddress=" + targetHostAddress + ", targetFragmentDuration=" + targetFragmentDuration
-                + ", properties=" + properties + ", outbound=" + outbound + "]";
     }
 
     /* (non-Javadoc)
@@ -531,8 +515,8 @@ public class CommunicationDetails implements Externalizable {
 
         id = ois.readUTF();
         businessTransaction = ois.readUTF();
-        uri = ois.readUTF();
-        originUri = ois.readUTF();
+        source = ois.readUTF();
+        target = ois.readUTF();
         multiConsumer = ois.readBoolean();
         timestamp = ois.readLong();
         latency = ois.readLong();
@@ -562,8 +546,8 @@ public class CommunicationDetails implements Externalizable {
 
         oos.writeUTF(id);
         oos.writeUTF(businessTransaction);
-        oos.writeUTF(uri);
-        oos.writeUTF(originUri);
+        oos.writeUTF(source);
+        oos.writeUTF(target);
         oos.writeBoolean(multiConsumer);
         oos.writeLong(timestamp);
         oos.writeLong(latency);

--- a/api/src/main/java/org/hawkular/btm/api/model/events/CompletionTime.java
+++ b/api/src/main/java/org/hawkular/btm/api/model/events/CompletionTime.java
@@ -36,6 +36,9 @@ public class CompletionTime {
     private String uri;
 
     @JsonInclude
+    private String operation;
+
+    @JsonInclude
     private String businessTransaction;
 
     @JsonInclude
@@ -76,6 +79,20 @@ public class CompletionTime {
      */
     public void setUri(String uri) {
         this.uri = uri;
+    }
+
+    /**
+     * @return the operation
+     */
+    public String getOperation() {
+        return operation;
+    }
+
+    /**
+     * @param operation the operation to set
+     */
+    public void setOperation(String operation) {
+        this.operation = operation;
     }
 
     /**
@@ -161,6 +178,7 @@ public class CompletionTime {
         result = prime * result + (int) (duration ^ (duration >>> 32));
         result = prime * result + ((fault == null) ? 0 : fault.hashCode());
         result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + ((operation == null) ? 0 : operation.hashCode());
         result = prime * result + ((properties == null) ? 0 : properties.hashCode());
         result = prime * result + (int) (timestamp ^ (timestamp >>> 32));
         result = prime * result + ((uri == null) ? 0 : uri.hashCode());
@@ -196,6 +214,11 @@ public class CompletionTime {
                 return false;
         } else if (!id.equals(other.id))
             return false;
+        if (operation == null) {
+            if (other.operation != null)
+                return false;
+        } else if (!operation.equals(other.operation))
+            return false;
         if (properties == null) {
             if (other.properties != null)
                 return false;
@@ -216,9 +239,9 @@ public class CompletionTime {
      */
     @Override
     public String toString() {
-        return "CompletionTime [id=" + id + ", uri=" + uri + ", businessTransaction=" + businessTransaction
-                + ", timestamp=" + timestamp + ", duration=" + duration + ", fault=" + fault + ", properties="
-                + properties + "]";
+        return "CompletionTime [id=" + id + ", uri=" + uri + ", operation=" + operation + ", businessTransaction="
+                + businessTransaction + ", timestamp=" + timestamp + ", duration=" + duration + ", fault=" + fault
+                + ", properties=" + properties + "]";
     }
 
 }

--- a/client/api/src/main/java/org/hawkular/btm/client/api/BusinessTransactionCollector.java
+++ b/client/api/src/main/java/org/hawkular/btm/client/api/BusinessTransactionCollector.java
@@ -92,9 +92,10 @@ public interface BusinessTransactionCollector {
      * @param location The instrumentation location
      * @param uri The uri
      * @param type The endpoint type
+     * @param operation The operation
      * @param id The unique interaction id
      */
-    void consumerStart(String location, String uri, String type, String id);
+    void consumerStart(String location, String uri, String type, String operation, String id);
 
     /**
      * This method indicates the end of a message being consumed.
@@ -102,8 +103,9 @@ public interface BusinessTransactionCollector {
      * @param location The instrumentation location
      * @param uri The uri
      * @param type The endpoint type
+     * @param operation The operation
      */
-    void consumerEnd(String location, String uri, String type);
+    void consumerEnd(String location, String uri, String type, String operation);
 
     /**
      * This method indicates the start of a component invocation.
@@ -131,9 +133,10 @@ public interface BusinessTransactionCollector {
      * @param location The instrumentation location
      * @param uri The uri
      * @param type The endpoint type
+     * @param operation The operation
      * @param id The unique interaction id
      */
-    void producerStart(String location, String uri, String type, String id);
+    void producerStart(String location, String uri, String type, String operation, String id);
 
     /**
      * This method indicates the end of a message being produced.
@@ -141,8 +144,9 @@ public interface BusinessTransactionCollector {
      * @param location The instrumentation location
      * @param uri The uri
      * @param type The endpoint type
+     * @param operation The operation
      */
-    void producerEnd(String location, String uri, String type);
+    void producerEnd(String location, String uri, String type, String operation);
 
     /**
      * This method identifies whether the in data (content and headers) for the current

--- a/client/btxn-collector/src/main/java/org/hawkular/btm/client/collector/DefaultBusinessTransactionCollector.java
+++ b/client/btxn-collector/src/main/java/org/hawkular/btm/client/collector/DefaultBusinessTransactionCollector.java
@@ -392,12 +392,13 @@ public class DefaultBusinessTransactionCollector implements BusinessTransactionC
 
     /* (non-Javadoc)
      * @see org.hawkular.btm.client.api.BusinessTransactionCollector#consumerStart(java.lang.String,
-     *                      java.lang.String, java.lang.String, java.lang.String)
+     *                      java.lang.String, java.lang.String, java.lang.String, java.lang.String)
      */
     @Override
-    public void consumerStart(String location, String uri, String type, String id) {
+    public void consumerStart(String location, String uri, String type, String operation, String id) {
         if (log.isLoggable(Level.FINEST)) {
-            log.finest("Consumer start: location=[" + location + "] type=" + type + " uri=" + uri + " id=" + id);
+            log.finest("Consumer start: location=[" + location + "] type=" + type + " operation="
+                    + operation + " uri=" + uri + " id=" + id);
         }
 
         try {
@@ -407,6 +408,7 @@ public class DefaultBusinessTransactionCollector implements BusinessTransactionC
                 Consumer consumer = new Consumer();
                 consumer.setEndpointType(type);
                 consumer.setUri(uri);
+                consumer.setOperation(operation);
 
                 if (id != null) {
                     consumer.getCorrelationIds().add(new CorrelationIdentifier(Scope.Interaction, id));
@@ -423,12 +425,13 @@ public class DefaultBusinessTransactionCollector implements BusinessTransactionC
 
     /* (non-Javadoc)
      * @see org.hawkular.btm.client.api.BusinessTransactionCollector#consumerEnd(java.lang.String,
-     *                          java.lang.String, java.lang.String)
+     *                          java.lang.String, java.lang.String, java.lang.String)
      */
     @Override
-    public void consumerEnd(String location, String uri, String type) {
+    public void consumerEnd(String location, String uri, String type, String operation) {
         if (log.isLoggable(Level.FINEST)) {
-            log.finest("Consumer end: location=[" + location + "] type=" + type + " uri=" + uri);
+            log.finest("Consumer end: location=[" + location + "] type=" + type + " operation="
+                    + operation + " uri=" + uri);
         }
 
         try {
@@ -509,13 +512,13 @@ public class DefaultBusinessTransactionCollector implements BusinessTransactionC
 
     /* (non-Javadoc)
      * @see org.hawkular.btm.client.api.BusinessTransactionCollector#producerStart(java.lang.String,
-     *                      java.lang.String, java.lang.String, java.lang.String)
+     *                      java.lang.String, java.lang.String, java.lang.String, java.lang.String)
      */
     @Override
-    public void producerStart(String location, String uri, String type, String id) {
+    public void producerStart(String location, String uri, String type, String operation, String id) {
         if (log.isLoggable(Level.FINEST)) {
-            log.finest("Producer start: location=[" + location + "] type=" + type
-                    + " uri=" + uri + " id=" + id);
+            log.finest("Producer start: location=[" + location + "] type=" + type + " operation="
+                    + operation + " uri=" + uri + " id=" + id);
         }
 
         try {
@@ -525,6 +528,7 @@ public class DefaultBusinessTransactionCollector implements BusinessTransactionC
                 Producer producer = new Producer();
                 producer.setEndpointType(type);
                 producer.setUri(uri);
+                producer.setOperation(operation);
 
                 if (id != null) {
                     producer.getCorrelationIds().add(new CorrelationIdentifier(Scope.Interaction, id));
@@ -541,12 +545,13 @@ public class DefaultBusinessTransactionCollector implements BusinessTransactionC
 
     /* (non-Javadoc)
      * @see org.hawkular.btm.client.api.BusinessTransactionCollector#producerEnd(java.lang.String,
-     *                          java.lang.String, java.lang.String)
+     *                          java.lang.String, java.lang.String, java.lang.String)
      */
     @Override
-    public void producerEnd(String location, String uri, String type) {
+    public void producerEnd(String location, String uri, String type, String operation) {
         if (log.isLoggable(Level.FINEST)) {
-            log.finest("Producer end: location=[" + location + "] type=" + type + " uri=" + uri);
+            log.finest("Producer end: location=[" + location + "] type=" + type + " operation="
+                    + operation + " uri=" + uri);
         }
 
         try {

--- a/client/btxn-collector/src/main/java/org/hawkular/btm/client/collector/internal/ProcessorManager.java
+++ b/client/btxn-collector/src/main/java/org/hawkular/btm/client/collector/internal/ProcessorManager.java
@@ -34,7 +34,6 @@ import org.hawkular.btm.api.model.btxn.BusinessTransaction;
 import org.hawkular.btm.api.model.btxn.Component;
 import org.hawkular.btm.api.model.btxn.Issue;
 import org.hawkular.btm.api.model.btxn.Node;
-import org.hawkular.btm.api.model.btxn.NodeType;
 import org.hawkular.btm.api.model.btxn.ProcessorIssue;
 import org.hawkular.btm.api.model.config.CollectorConfiguration;
 import org.hawkular.btm.api.model.config.Direction;
@@ -415,8 +414,8 @@ public class ProcessorManager {
                     return;
                 }
 
-                // Check if operation has been specified, and node is Component
-                if (processor.getOperation() != null && node.getType() == NodeType.Component
+                // Check if operation has been specified
+                if (processor.getOperation() != null
                         && !processor.getOperation().equals(((Component) node).getOperation())) {
                     return;
                 }

--- a/client/btxn-collector/src/test/java/org/hawkular/btm/client/collector/DefaultBusinessTransactionCollectorTest.java
+++ b/client/btxn-collector/src/test/java/org/hawkular/btm/client/collector/DefaultBusinessTransactionCollectorTest.java
@@ -58,6 +58,8 @@ public class DefaultBusinessTransactionCollectorTest {
     private static final String TYPE = "TestType";
     /**  */
     private static final String URI = "TestURI";
+    /**  */
+    private static final String OP = "TestOP";
 
     @Test
     public void testSetStartTimeAndDuration() {
@@ -66,7 +68,7 @@ public class DefaultBusinessTransactionCollectorTest {
         collector.setBusinessTransactionPublisher(btxnService);
         collector.setConfigurationService(new TestConfigurationService());
 
-        collector.consumerStart(null, URI, TYPE, null);
+        collector.consumerStart(null, URI, TYPE, OP, null);
 
         // Delay, to provide a reasonable value for duration
         synchronized (this) {
@@ -77,7 +79,7 @@ public class DefaultBusinessTransactionCollectorTest {
             }
         }
 
-        collector.consumerEnd(null, URI, TYPE);
+        collector.consumerEnd(null, URI, TYPE, OP);
 
         // Delay necessary as reporting the business transaction is performed in a separate
         // thread
@@ -112,9 +114,9 @@ public class DefaultBusinessTransactionCollectorTest {
         collector.setBusinessTransactionPublisher(btxnService);
         collector.setConfigurationService(new TestConfigurationService());
 
-        collector.consumerStart(null, URI, TYPE, null);
+        collector.consumerStart(null, URI, TYPE, OP, null);
 
-        collector.consumerEnd(null, URI, TYPE);
+        collector.consumerEnd(null, URI, TYPE, OP);
 
         // Delay necessary as reporting the business transaction is performed in a separate
         // thread
@@ -147,10 +149,10 @@ public class DefaultBusinessTransactionCollectorTest {
         Map<String, String> respHeaders = new HashMap<String, String>();
         respHeaders.put("joe", "bloggs");
 
-        collector.consumerStart(null, URI, TYPE, null);
+        collector.consumerStart(null, URI, TYPE, OP, null);
         collector.processIn(null, reqHeaders);
         collector.processOut(null, respHeaders);
-        collector.consumerEnd(null, URI, TYPE);
+        collector.consumerEnd(null, URI, TYPE, OP);
 
         // Delay necessary as reporting the business transaction is performed in a separate
         // thread
@@ -192,10 +194,10 @@ public class DefaultBusinessTransactionCollectorTest {
         Map<String, String> reqHeaders2 = new HashMap<String, String>();
         reqHeaders2.put("joe", "bloggs");
 
-        collector.consumerStart(null, URI, TYPE, null);
+        collector.consumerStart(null, URI, TYPE, OP, null);
         collector.processIn(null, reqHeaders);
         collector.processIn(null, reqHeaders2);
-        collector.consumerEnd(null, URI, TYPE);
+        collector.consumerEnd(null, URI, TYPE, OP);
 
         // Delay necessary as reporting the business transaction is performed in a separate
         // thread
@@ -233,10 +235,10 @@ public class DefaultBusinessTransactionCollectorTest {
         Map<String, String> reqHeaders = new HashMap<String, String>();
         reqHeaders.put("hello", "world");
 
-        collector.consumerStart(null, URI, TYPE, null);
+        collector.consumerStart(null, URI, TYPE, OP, null);
         collector.processIn(null, null);
         collector.processIn(null, reqHeaders);
-        collector.consumerEnd(null, URI, TYPE);
+        collector.consumerEnd(null, URI, TYPE, OP);
 
         // Delay necessary as reporting the business transaction is performed in a separate
         // thread
@@ -270,9 +272,9 @@ public class DefaultBusinessTransactionCollectorTest {
         collector.setBusinessTransactionPublisher(btxnService);
         collector.setConfigurationService(new TestConfigurationService());
 
-        collector.consumerStart(null, null, null, "myid");
+        collector.consumerStart(null, null, null, null, "myid");
 
-        collector.consumerEnd(null, null, null);
+        collector.consumerEnd(null, null, null, null);
 
         // Delay necessary as reporting the business transaction is performed in a separate
         // thread
@@ -322,9 +324,9 @@ public class DefaultBusinessTransactionCollectorTest {
 
         collector.activate("/test");
 
-        collector.consumerStart(null, "/test", null, null);
+        collector.consumerStart(null, "/test", null, null, null);
 
-        collector.consumerEnd(null, null, null);
+        collector.consumerEnd(null, null, null, null);
 
         // Delay necessary as reporting the business transaction is performed in a separate
         // thread
@@ -363,9 +365,9 @@ public class DefaultBusinessTransactionCollectorTest {
 
         collector.setLevel(null, "None");
 
-        collector.consumerStart(null, "/test", null, null);
+        collector.consumerStart(null, "/test", null, null, null);
 
-        collector.consumerEnd(null, null, null);
+        collector.consumerEnd(null, null, null, null);
 
         // Delay necessary as reporting the business transaction is performed in a separate
         // thread
@@ -402,9 +404,9 @@ public class DefaultBusinessTransactionCollectorTest {
 
         collector.activate("/test");
 
-        collector.consumerStart(null, "/test", null, null);
+        collector.consumerStart(null, "/test", null, null, null);
 
-        collector.consumerEnd(null, null, null);
+        collector.consumerEnd(null, null, null, null);
 
         // Delay necessary as reporting the business transaction is performed in a separate
         // thread
@@ -503,7 +505,7 @@ public class DefaultBusinessTransactionCollectorTest {
 
         // Cause a fragment builder to be created
         collector.activate("/test");
-        collector.producerStart(null, "/test", "HTTP", null);
+        collector.producerStart(null, "/test", "HTTP", null, null);
 
         collector.setName(null, "test");
 
@@ -541,7 +543,7 @@ public class DefaultBusinessTransactionCollectorTest {
 
         // Cause a fragment builder to be created
         collector.activate("/test");
-        collector.producerStart(null, "/test", "HTTP", null);
+        collector.producerStart(null, "/test", "HTTP", null, null);
 
         collector.setPrincipal(null, "test");
 
@@ -570,7 +572,7 @@ public class DefaultBusinessTransactionCollectorTest {
 
         // Cause a fragment builder to be created
         collector.activate("/test");
-        collector.producerStart(null, "/test", "HTTP", null);
+        collector.producerStart(null, "/test", "HTTP", null, null);
 
         assertTrue(collector.isActive());
         assertEquals("testapp", collector.getName());
@@ -602,7 +604,7 @@ public class DefaultBusinessTransactionCollectorTest {
 
         // Cause a fragment builder to be created
         collector.activate("/test");
-        collector.producerStart(null, "/test", "HTTP", null);
+        collector.producerStart(null, "/test", "HTTP", null, null);
 
         assertTrue(collector.isActive());
         assertEquals("testapp", collector.getName());
@@ -630,13 +632,13 @@ public class DefaultBusinessTransactionCollectorTest {
 
         // Create top level node
         collector.activate("not relevant");
-        collector.consumerStart(null, "not relevant", "HTTP", null);
+        collector.consumerStart(null, "not relevant", "HTTP", null, null);
         collector.getFragmentManager().getFragmentBuilder()
             .getBusinessTransaction().getNodes().get(0).addInteractionId("testId");
 
         // Cause a fragment builder to be created
         collector.activate("/test");
-        collector.producerStart(null, "/test", "HTTP", null);
+        collector.producerStart(null, "/test", "HTTP", null, null);
 
         assertTrue(collector.isActive());
         assertEquals("", collector.getName());
@@ -651,7 +653,7 @@ public class DefaultBusinessTransactionCollectorTest {
         // Cause a fragment builder to be created
         FragmentBuilder builder = collector.getFragmentManager().getFragmentBuilder();
 
-        collector.consumerStart(null, "testconsumer", "testtype", "testid");
+        collector.consumerStart(null, "testconsumer", "testtype", "testop", "testid");
 
         Node node = builder.getCurrentNode();
 
@@ -671,7 +673,7 @@ public class DefaultBusinessTransactionCollectorTest {
         // Cause a fragment builder to be created
         FragmentBuilder builder = collector.getFragmentManager().getFragmentBuilder();
 
-        collector.consumerStart(null, "testconsumer", "testtype", "testid");
+        collector.consumerStart(null, "testconsumer", "testtype", "testop", "testid");
 
         Consumer consumer = (Consumer) builder.getCurrentNode();
 
@@ -698,7 +700,7 @@ public class DefaultBusinessTransactionCollectorTest {
         // Cause a fragment builder to be created
         FragmentBuilder builder = collector.getFragmentManager().getFragmentBuilder();
 
-        collector.consumerStart(null, "testconsumer", "testcontype", "testconid");
+        collector.consumerStart(null, "testconsumer", "testcontype", "testop", "testconid");
 
         Consumer consumer = (Consumer) builder.getCurrentNode();
 
@@ -716,14 +718,14 @@ public class DefaultBusinessTransactionCollectorTest {
 
         assertNotNull(component2);
 
-        collector.producerStart(null, "testproducer", "testprodtype", "tesprodid");
+        collector.producerStart(null, "testproducer", "testprodtype", "testop", "tesprodid");
 
         Producer producer = (Producer) builder.getCurrentNode();
 
         assertNotNull(producer);
 
         // Pop the producer and one of the components
-        collector.producerEnd(null, "testproducer", "testprodtype");
+        collector.producerEnd(null, "testproducer", "testprodtype", "testop");
         collector.componentEnd(null, "testcomponent2", "testcomptype", "testcompop");
 
         collector.setDetail(null, "testname", "testvalue", "Producer", false);
@@ -742,19 +744,19 @@ public class DefaultBusinessTransactionCollectorTest {
         // Cause a fragment builder to be created
         FragmentBuilder builder = collector.getFragmentManager().getFragmentBuilder();
 
-        collector.consumerStart(null, "testconsumer", "testcontype", "testconid");
+        collector.consumerStart(null, "testconsumer", "testcontype", "testop", "testconid");
 
         Consumer consumer = (Consumer) builder.getCurrentNode();
 
         assertNotNull(consumer);
 
-        collector.producerStart(null, "testproducer", "testprodtype", "testprodid1");
+        collector.producerStart(null, "testproducer", "testprodtype", "testop", "testprodid1");
 
         Producer producerOuter = (Producer) builder.getCurrentNode();
 
         assertNotNull(producerOuter);
 
-        collector.producerStart(null, "testproducer", "testprodtype", "testprodid2");
+        collector.producerStart(null, "testproducer", "testprodtype", "testop", "testprodid2");
 
         Producer producerInner = (Producer) builder.getCurrentNode();
 
@@ -767,8 +769,8 @@ public class DefaultBusinessTransactionCollectorTest {
         assertTrue(producerOuter.getCorrelationIds().get(0).getValue().equals("testprodid1"));
 
         // Pop the producer and one of the components
-        collector.producerEnd(null, "testproducer", "testprodtype");
-        collector.producerEnd(null, "testproducer", "testprodtype");
+        collector.producerEnd(null, "testproducer", "testprodtype", "testop");
+        collector.producerEnd(null, "testproducer", "testprodtype", "testop");
 
         // After merge
         assertFalse(producerOuter.getNodes().contains(producerInner));

--- a/client/btxn-instrumentation/src/main/resources/btmconfig/io/netty/btm-netty-http.json
+++ b/client/btxn-instrumentation/src/main/resources/btmconfig/io/netty/btm-netty-http.json
@@ -28,6 +28,7 @@
           "direction": "In",
           "endpointTypeExpression": "\"HTTP\"",
           "uriExpression": "(new java.net.URI(\"http://\"+req.headers().get(\"host\")+req.getUri())).getPath()",
+          "operationExpression": "req.getMethod().name()",
           "idExpression": "id"
         },{
           "type": "ProcessHeaders",

--- a/client/btxn-instrumentation/src/main/resources/btmconfig/io/vertx/btm-vertx-http.json
+++ b/client/btxn-instrumentation/src/main/resources/btmconfig/io/vertx/btm-vertx-http.json
@@ -21,6 +21,7 @@
           "type": "InstrumentConsumer",
           "direction": "In",
           "endpointTypeExpression": "\"HTTP\"",
+          "operationExpression": "$0.method()",
           "uriExpression": "$0.path()",
           "idExpression": "$0.getHeader(\"Hawkularbtid\")"
         },{
@@ -105,6 +106,7 @@
           "type": "InstrumentProducer",
           "direction": "In",
           "endpointTypeExpression": "\"HTTP\"",
+          "operationExpression": "$0.method()",
           "uriExpression": "uri.getPath()",
           "idExpression": "id"
         },{
@@ -172,6 +174,7 @@
           "type": "InstrumentProducer",
           "direction": "In",
           "endpointTypeExpression": "\"HTTP\"",
+          "operationExpression": "$0.method()",
           "uriExpression": "uri.getPath()",
           "idExpression": "id"
         },{

--- a/client/btxn-instrumentation/src/main/resources/btmconfig/java/btm-java-jdbc.json
+++ b/client/btxn-instrumentation/src/main/resources/btmconfig/java/btm-java-jdbc.json
@@ -15,6 +15,7 @@
           "type": "InstrumentComponent",
           "direction": "In",
           "componentTypeExpression": "\"Database\"",
+          "operationExpression": "\"query\"",
           "uriExpression": "$0.getConnection().getMetaData().getURL()"
         },{
           "type": "SetDetail",
@@ -58,6 +59,7 @@
           "type": "InstrumentComponent",
           "direction": "In",
           "componentTypeExpression": "\"Database\"",
+          "operationExpression": "\"query\"",
           "uriExpression": "$0.getConnection().getMetaData().getURL()"
         },{
           "type": "SetDetail",
@@ -101,6 +103,7 @@
           "type": "InstrumentComponent",
           "direction": "In",
           "componentTypeExpression": "\"Database\"",
+          "operationExpression": "\"update\"",
           "uriExpression": "$0.getConnection().getMetaData().getURL()"
         },{
           "type": "SetDetail",
@@ -144,6 +147,7 @@
           "type": "InstrumentComponent",
           "direction": "In",
           "componentTypeExpression": "\"Database\"",
+          "operationExpression": "\"update\"",
           "uriExpression": "$0.getConnection().getMetaData().getURL()"
         },{
           "type": "SetDetail",

--- a/client/btxn-instrumentation/src/main/resources/btmconfig/java/btm-java-net.json
+++ b/client/btxn-instrumentation/src/main/resources/btmconfig/java/btm-java-net.json
@@ -19,6 +19,7 @@
           "type": "InstrumentProducer",
           "direction": "In",
           "endpointTypeExpression": "\"HTTP\"",
+          "operationExpression": "$0.getRequestMethod()",
           "uriExpression": "$0.getURL().getPath()",
           "idExpression": "id"
         },{
@@ -98,6 +99,7 @@
           "type": "InstrumentProducer",
           "direction": "In",
           "endpointTypeExpression": "\"HTTP\"",
+          "operationExpression": "$0.getRequestMethod()",
           "uriExpression": "$0.getURL().getPath()",
           "idExpression": "id"
         },{
@@ -183,6 +185,7 @@
           "type": "InstrumentProducer",
           "direction": "In",
           "endpointTypeExpression": "\"HTTP\"",
+          "operationExpression": "$0.getRequestMethod()",
           "uriExpression": "$0.getURL().getPath()",
           "idExpression": "id"
         },{

--- a/client/btxn-instrumentation/src/main/resources/btmconfig/javax/btm-javax-servlet.json
+++ b/client/btxn-instrumentation/src/main/resources/btmconfig/javax/btm-javax-servlet.json
@@ -31,6 +31,7 @@
           "type": "InstrumentConsumer",
           "direction": "In",
           "endpointTypeExpression": "\"HTTP\"",
+          "operationExpression": "req.getMethod()",
           "uriExpression": "uri.getPath()",
           "idExpression": "req.getHeader(\"Hawkularbtid\")"
         },{

--- a/client/btxn-instrumentation/src/main/resources/btmconfig/org/apache/btm-org-apache-httpclient.json
+++ b/client/btxn-instrumentation/src/main/resources/btmconfig/org/apache/btm-org-apache-httpclient.json
@@ -24,6 +24,7 @@
           "type": "InstrumentProducer",
           "direction": "In",
           "endpointTypeExpression": "\"HTTP\"",
+          "operationExpression": "$2.getRequestLine().getMethod()",
           "uriExpression": "uri.getPath()",
           "idExpression": "id"
         },{

--- a/client/client-manager/src/main/java/org/hawkular/btm/client/manager/config/InstrumentConsumerTransformer.java
+++ b/client/client-manager/src/main/java/org/hawkular/btm/client/manager/config/InstrumentConsumerTransformer.java
@@ -49,13 +49,14 @@ public class InstrumentConsumerTransformer extends CollectorActionTransformer {
      */
     @Override
     protected String[] getParameters(CollectorAction invocation) {
-        String[] ret = new String[invocation.getDirection() == Direction.In ? 3 : 2];
+        String[] ret = new String[invocation.getDirection() == Direction.In ? 4 : 3];
 
         ret[0] = ((InstrumentConsumer) invocation).getUriExpression();
         ret[1] = ((InstrumentConsumer) invocation).getEndpointTypeExpression();
+        ret[2] = ((InstrumentConsumer) invocation).getOperationExpression();
 
         if (invocation.getDirection() == Direction.In) {
-            ret[2] = ((InstrumentConsumer) invocation).getIdExpression();
+            ret[3] = ((InstrumentConsumer) invocation).getIdExpression();
         }
 
         return (ret);

--- a/client/client-manager/src/main/java/org/hawkular/btm/client/manager/config/InstrumentProducerTransformer.java
+++ b/client/client-manager/src/main/java/org/hawkular/btm/client/manager/config/InstrumentProducerTransformer.java
@@ -49,13 +49,14 @@ public class InstrumentProducerTransformer extends CollectorActionTransformer {
      */
     @Override
     protected String[] getParameters(CollectorAction invocation) {
-        String[] ret = new String[invocation.getDirection() == Direction.In ? 3 : 2];
+        String[] ret = new String[invocation.getDirection() == Direction.In ? 4 : 3];
 
         ret[0] = ((InstrumentProducer) invocation).getUriExpression();
         ret[1] = ((InstrumentProducer) invocation).getEndpointTypeExpression();
+        ret[2] = ((InstrumentProducer) invocation).getOperationExpression();
 
         if (invocation.getDirection() == Direction.In) {
-            ret[2] = ((InstrumentProducer) invocation).getIdExpression();
+            ret[3] = ((InstrumentProducer) invocation).getIdExpression();
         }
 
         return (ret);

--- a/client/client-manager/src/test/java/org/hawkular/btm/client/manager/config/InstrumentConsumerTransformerTest.java
+++ b/client/client-manager/src/test/java/org/hawkular/btm/client/manager/config/InstrumentConsumerTransformerTest.java
@@ -35,12 +35,13 @@ public class InstrumentConsumerTransformerTest {
 
         im.setEndpointTypeExpression("\"MyEndpoint\"");
         im.setUriExpression("\"MyUri\"");
+        im.setOperationExpression("\"MyOperation\"");
 
         InstrumentConsumerTransformer transformer = new InstrumentConsumerTransformer();
 
         String transformed = transformer.convertToRuleAction(im);
 
-        String expected = ACTION_PREFIX + "consumerStart(getRuleName(),\"MyUri\",\"MyEndpoint\",null)";
+        String expected = ACTION_PREFIX + "consumerStart(getRuleName(),\"MyUri\",\"MyEndpoint\",\"MyOperation\",null)";
 
         assertEquals(expected, transformed);
     }
@@ -51,13 +52,15 @@ public class InstrumentConsumerTransformerTest {
 
         im.setEndpointTypeExpression("\"MyEndpoint\"");
         im.setUriExpression("\"MyUri\"");
+        im.setOperationExpression("\"MyOperation\"");
         im.setIdExpression("\"MyId\"");
 
         InstrumentConsumerTransformer transformer = new InstrumentConsumerTransformer();
 
         String transformed = transformer.convertToRuleAction(im);
 
-        String expected = ACTION_PREFIX + "consumerStart(getRuleName(),\"MyUri\",\"MyEndpoint\",\"MyId\")";
+        String expected = ACTION_PREFIX +
+                "consumerStart(getRuleName(),\"MyUri\",\"MyEndpoint\",\"MyOperation\",\"MyId\")";
 
         assertEquals(expected, transformed);
     }
@@ -68,13 +71,14 @@ public class InstrumentConsumerTransformerTest {
 
         im.setEndpointTypeExpression("\"MyEndpoint\"");
         im.setUriExpression("\"MyUri\"");
+        im.setOperationExpression("\"MyOperation\"");
         im.setDirection(Direction.Out);
 
         InstrumentConsumerTransformer transformer = new InstrumentConsumerTransformer();
 
         String transformed = transformer.convertToRuleAction(im);
 
-        String expected = ACTION_PREFIX + "consumerEnd(getRuleName(),\"MyUri\",\"MyEndpoint\")";
+        String expected = ACTION_PREFIX + "consumerEnd(getRuleName(),\"MyUri\",\"MyEndpoint\",\"MyOperation\")";
 
         assertEquals(expected, transformed);
     }
@@ -85,6 +89,7 @@ public class InstrumentConsumerTransformerTest {
 
         im.setEndpointTypeExpression("\"MyEndpoint\"");
         im.setUriExpression("\"MyUri\"");
+        im.setOperationExpression("\"MyOperation\"");
         im.setIdExpression("\"MyId\"");
         im.setDirection(Direction.Out);
 
@@ -92,7 +97,7 @@ public class InstrumentConsumerTransformerTest {
 
         String transformed = transformer.convertToRuleAction(im);
 
-        String expected = ACTION_PREFIX + "consumerEnd(getRuleName(),\"MyUri\",\"MyEndpoint\")";
+        String expected = ACTION_PREFIX + "consumerEnd(getRuleName(),\"MyUri\",\"MyEndpoint\",\"MyOperation\")";
 
         assertEquals(expected, transformed);
     }

--- a/client/client-manager/src/test/java/org/hawkular/btm/client/manager/config/InstrumentProducerTransformerTest.java
+++ b/client/client-manager/src/test/java/org/hawkular/btm/client/manager/config/InstrumentProducerTransformerTest.java
@@ -35,12 +35,13 @@ public class InstrumentProducerTransformerTest {
 
         im.setEndpointTypeExpression("\"MyEndpoint\"");
         im.setUriExpression("\"MyUri\"");
+        im.setOperationExpression("\"MyOperation\"");
 
         InstrumentProducerTransformer transformer = new InstrumentProducerTransformer();
 
         String transformed = transformer.convertToRuleAction(im);
 
-        String expected = ACTION_PREFIX + "producerStart(getRuleName(),\"MyUri\",\"MyEndpoint\",null)";
+        String expected = ACTION_PREFIX + "producerStart(getRuleName(),\"MyUri\",\"MyEndpoint\",\"MyOperation\",null)";
 
         assertEquals(expected, transformed);
     }
@@ -51,13 +52,15 @@ public class InstrumentProducerTransformerTest {
 
         im.setEndpointTypeExpression("\"MyEndpoint\"");
         im.setUriExpression("\"MyUri\"");
+        im.setOperationExpression("\"MyOperation\"");
         im.setIdExpression("\"MyId\"");
 
         InstrumentProducerTransformer transformer = new InstrumentProducerTransformer();
 
         String transformed = transformer.convertToRuleAction(im);
 
-        String expected = ACTION_PREFIX + "producerStart(getRuleName(),\"MyUri\",\"MyEndpoint\",\"MyId\")";
+        String expected = ACTION_PREFIX +
+                "producerStart(getRuleName(),\"MyUri\",\"MyEndpoint\",\"MyOperation\",\"MyId\")";
 
         assertEquals(expected, transformed);
     }
@@ -68,13 +71,14 @@ public class InstrumentProducerTransformerTest {
 
         im.setEndpointTypeExpression("\"MyEndpoint\"");
         im.setUriExpression("\"MyUri\"");
+        im.setOperationExpression("\"MyOperation\"");
         im.setDirection(Direction.Out);
 
         InstrumentProducerTransformer transformer = new InstrumentProducerTransformer();
 
         String transformed = transformer.convertToRuleAction(im);
 
-        String expected = ACTION_PREFIX + "producerEnd(getRuleName(),\"MyUri\",\"MyEndpoint\")";
+        String expected = ACTION_PREFIX + "producerEnd(getRuleName(),\"MyUri\",\"MyEndpoint\",\"MyOperation\")";
 
         assertEquals(expected, transformed);
     }
@@ -85,13 +89,14 @@ public class InstrumentProducerTransformerTest {
 
         im.setEndpointTypeExpression("\"MyEndpoint\"");
         im.setUriExpression("\"MyUri\"");
+        im.setOperationExpression("\"MyOperation\"");
         im.setDirection(Direction.Out);
 
         InstrumentProducerTransformer transformer = new InstrumentProducerTransformer();
 
         String transformed = transformer.convertToRuleAction(im);
 
-        String expected = ACTION_PREFIX + "producerEnd(getRuleName(),\"MyUri\",\"MyEndpoint\")";
+        String expected = ACTION_PREFIX + "producerEnd(getRuleName(),\"MyUri\",\"MyEndpoint\",\"MyOperation\")";
 
         assertEquals(expected, transformed);
     }

--- a/processors/btxncompletiontime-deriver/src/main/java/org/hawkular/btm/processor/btxncompletiontime/BTxnCompletionInformationInitiator.java
+++ b/processors/btxncompletiontime-deriver/src/main/java/org/hawkular/btm/processor/btxncompletiontime/BTxnCompletionInformationInitiator.java
@@ -62,6 +62,7 @@ public class BTxnCompletionInformationInitiator extends
                 CompletionTime ct = new CompletionTime();
                 ct.setId(item.getId());
                 ct.setUri(n.getUri());
+                ct.setOperation(n.getOperation());
                 ct.setBusinessTransaction(item.getName());
                 ct.setDuration(item.calculateDuration());
                 ct.setFault(n.getFault());

--- a/processors/communicationdetails-deriver/src/main/java/org/hawkular/btm/processor/communicationdetails/ProducerInfo.java
+++ b/processors/communicationdetails-deriver/src/main/java/org/hawkular/btm/processor/communicationdetails/ProducerInfo.java
@@ -29,7 +29,9 @@ import java.io.ObjectOutput;
  */
 public class ProducerInfo implements Externalizable {
 
-    private String originUri;
+    private String sourceUri;
+
+    private String sourceOperation;
 
     private long timestamp = 0;
 
@@ -44,17 +46,31 @@ public class ProducerInfo implements Externalizable {
     private boolean multipleConsumers = false;
 
     /**
-     * @return the originUri
+     * @return the sourceUri
      */
-    public String getOriginUri() {
-        return originUri;
+    public String getSourceUri() {
+        return sourceUri;
     }
 
     /**
-     * @param originUri the originUri to set
+     * @param sourceUri the sourceUri to set
      */
-    public void setOriginUri(String originUri) {
-        this.originUri = originUri;
+    public void setSourceUri(String sourceUri) {
+        this.sourceUri = sourceUri;
+    }
+
+    /**
+     * @return the sourceOperation
+     */
+    public String getSourceOperation() {
+        return sourceOperation;
+    }
+
+    /**
+     * @param sourceOperation the sourceOperation to set
+     */
+    public void setSourceOperation(String sourceOperation) {
+        this.sourceOperation = sourceOperation;
     }
 
     /**
@@ -148,7 +164,8 @@ public class ProducerInfo implements Externalizable {
     public void readExternal(ObjectInput ois) throws IOException, ClassNotFoundException {
         ois.readInt(); // Read version
 
-        originUri = ois.readUTF();
+        sourceUri = ois.readUTF();
+        sourceOperation = ois.readUTF();
         timestamp = ois.readLong();
         duration = ois.readLong();
         fragmentId = ois.readUTF();
@@ -164,7 +181,8 @@ public class ProducerInfo implements Externalizable {
     public void writeExternal(ObjectOutput oos) throws IOException {
         oos.writeInt(1); // Write version
 
-        oos.writeUTF(originUri);
+        oos.writeUTF(sourceUri);
+        oos.writeUTF(sourceOperation);
         oos.writeLong(timestamp);
         oos.writeLong(duration);
         oos.writeUTF(fragmentId);

--- a/processors/communicationdetails-deriver/src/test/java/org/hawkular/btm/processor/communicationdetails/CommunicationDetailsDeriverTest.java
+++ b/processors/communicationdetails-deriver/src/test/java/org/hawkular/btm/processor/communicationdetails/CommunicationDetailsDeriverTest.java
@@ -131,12 +131,12 @@ public class CommunicationDetailsDeriverTest {
         assertNotNull(pi1);
         assertNotNull(pi2);
 
-        assertEquals(CommunicationDetailsDeriver.CLIENT_PREFIX + "p1", pi1.getOriginUri());
+        assertEquals(CommunicationDetailsDeriver.CLIENT_PREFIX + "p1", pi1.getSourceUri());
 
         // Check that producer info 2 has same origin URI as p1, as they
         // are from the same fragment (without a consumer) so are being identified
         // as a client of the first producer URI found (see HWKBTM-353).
-        assertEquals(CommunicationDetailsDeriver.CLIENT_PREFIX + "p1", pi2.getOriginUri());
+        assertEquals(CommunicationDetailsDeriver.CLIENT_PREFIX + "p1", pi2.getSourceUri());
     }
 
     @Test
@@ -187,8 +187,8 @@ public class CommunicationDetailsDeriverTest {
         assertNotNull(pi1);
         assertNotNull(pi2);
 
-        assertEquals("consumerURI", pi1.getOriginUri());
-        assertEquals("consumerURI", pi2.getOriginUri());
+        assertEquals("consumerURI", pi1.getSourceUri());
+        assertEquals("consumerURI", pi2.getSourceUri());
     }
 
     @Test
@@ -306,8 +306,8 @@ public class CommunicationDetailsDeriverTest {
 
         assertEquals("pid1", details.getId());
         assertEquals(BTXN_NAME, details.getBusinessTransaction());
-        assertEquals("FirstURI", details.getOriginUri());
-        assertEquals("SecondURI", details.getUri());
+        assertEquals("FirstURI", details.getSource());
+        assertEquals("SecondURI", details.getTarget());
 
         assertFalse(details.isMultiConsumer());
 
@@ -476,8 +476,8 @@ public class CommunicationDetailsDeriverTest {
 
         assertEquals("pid1", details.getId());
         assertEquals(BTXN_NAME, details.getBusinessTransaction());
-        assertEquals(CommunicationDetailsDeriver.CLIENT_PREFIX + "TheURI", details.getOriginUri());
-        assertEquals("TheURI", details.getUri());
+        assertEquals(CommunicationDetailsDeriver.CLIENT_PREFIX + "TheURI", details.getSource());
+        assertEquals("TheURI", details.getTarget());
         assertTrue(c2.getDuration() == details.getConsumerDuration());
         assertTrue(p1.getDuration() == details.getProducerDuration());
         assertTrue(400 == details.getLatency());

--- a/processors/fragmentcompletiontime-deriver/src/main/java/org/hawkular/btm/processor/fragmentcompletiontime/FragmentCompletionTimeDeriver.java
+++ b/processors/fragmentcompletiontime-deriver/src/main/java/org/hawkular/btm/processor/fragmentcompletiontime/FragmentCompletionTimeDeriver.java
@@ -54,6 +54,7 @@ public class FragmentCompletionTimeDeriver extends AbstractProcessor<BusinessTra
             CompletionTime ct = new CompletionTime();
             ct.setId(item.getId());
             ct.setUri(n.getUri());
+            ct.setOperation(n.getOperation());
             ct.setBusinessTransaction(item.getName());
             ct.setDuration(item.calculateDuration());
             ct.setFault(n.getFault());

--- a/processors/nodedetails-deriver/src/main/java/org/hawkular/btm/processor/nodedetails/NodeDetailsDeriver.java
+++ b/processors/nodedetails-deriver/src/main/java/org/hawkular/btm/processor/nodedetails/NodeDetailsDeriver.java
@@ -110,7 +110,6 @@ public class NodeDetailsDeriver extends AbstractProcessor<BusinessTransaction, N
 
             if (n.getType() == NodeType.Component) {
                 nd.setComponentType(((Component) n).getComponentType());
-                nd.setOperation(((Component) n).getOperation());
             } else {
                 nd.setComponentType(n.getType().name());
             }
@@ -127,6 +126,7 @@ public class NodeDetailsDeriver extends AbstractProcessor<BusinessTransaction, N
             nd.setTimestamp(btxn.getStartTime() + diffms);
             nd.setType(n.getType());
             nd.setUri(n.getUri());
+            nd.setOperation(n.getOperation());
 
             rts.add(nd);
 

--- a/server/elasticsearch/src/test/java/org/hawkular/btm/server/elasticsearch/AnalyticsServiceElasticsearchTest.java
+++ b/server/elasticsearch/src/test/java/org/hawkular/btm/server/elasticsearch/AnalyticsServiceElasticsearchTest.java
@@ -1468,7 +1468,7 @@ public class AnalyticsServiceElasticsearchTest {
     }
 
     @Test
-    public void testGetCommunicationSummaryStatistics() {
+    public void testGetCommunicationSummaryStatisticsWithoutOps() {
         List<CommunicationDetails> cds = new ArrayList<CommunicationDetails>();
         List<CompletionTime> cts = new ArrayList<CompletionTime>();
 
@@ -1529,8 +1529,8 @@ public class AnalyticsServiceElasticsearchTest {
         cd1.setBusinessTransaction("testapp");
         cd1.setTimestamp(1500);
         cd1.setLatency(100);
-        cd1.setOriginUri("in1");
-        cd1.setUri("out1.1");
+        cd1.setSource("in1");
+        cd1.setTarget("out1.1");
         cds.add(cd1);
 
         CommunicationDetails cd2 = new CommunicationDetails();
@@ -1538,8 +1538,8 @@ public class AnalyticsServiceElasticsearchTest {
         cd2.setBusinessTransaction("testapp");
         cd2.setTimestamp(1500);
         cd2.setLatency(200);
-        cd2.setOriginUri("in1");
-        cd2.setUri("out1.2");
+        cd2.setSource("in1");
+        cd2.setTarget("out1.2");
         cds.add(cd2);
 
         CommunicationDetails cd3 = new CommunicationDetails();
@@ -1547,8 +1547,8 @@ public class AnalyticsServiceElasticsearchTest {
         cd3.setBusinessTransaction("testapp");
         cd3.setTimestamp(1500);
         cd3.setLatency(300);
-        cd3.setOriginUri("in2");
-        cd3.setUri("out2.1");
+        cd3.setSource("in2");
+        cd3.setTarget("out2.1");
         cds.add(cd3);
 
         CommunicationDetails cd4 = new CommunicationDetails();
@@ -1556,8 +1556,8 @@ public class AnalyticsServiceElasticsearchTest {
         cd4.setBusinessTransaction("testapp");
         cd4.setTimestamp(1600);
         cd4.setLatency(300);
-        cd4.setOriginUri("in1");
-        cd4.setUri("out1.2");
+        cd4.setSource("in1");
+        cd4.setTarget("out1.2");
         cds.add(cd4);
 
         CommunicationDetails cd5 = new CommunicationDetails();
@@ -1565,8 +1565,8 @@ public class AnalyticsServiceElasticsearchTest {
         cd5.setBusinessTransaction("testapp");
         cd5.setTimestamp(1600);
         cd5.setLatency(500);
-        cd5.setOriginUri("in2");
-        cd5.setUri("out2.1");
+        cd5.setSource("in2");
+        cd5.setTarget("out2.1");
         cds.add(cd5);
 
         try {
@@ -1594,18 +1594,18 @@ public class AnalyticsServiceElasticsearchTest {
         CommunicationSummaryStatistics out2_1 = null;
 
         for (CommunicationSummaryStatistics css : stats) {
-            if (css.getUri().equals("in1")) {
+            if (css.getId().equals("in1")) {
                 in1 = css;
-            } else if (css.getUri().equals("in2")) {
+            } else if (css.getId().equals("in2")) {
                 in2 = css;
-            } else if (css.getUri().equals("out1.1")) {
+            } else if (css.getId().equals("out1.1")) {
                 out1_1 = css;
-            } else if (css.getUri().equals("out1.2")) {
+            } else if (css.getId().equals("out1.2")) {
                 out1_2 = css;
-            } else if (css.getUri().equals("out2.1")) {
+            } else if (css.getId().equals("out2.1")) {
                 out2_1 = css;
             } else {
-                fail("Unexpected uri: " + css.getUri());
+                fail("Unexpected uri: " + css.getId());
             }
         }
 
@@ -1649,6 +1649,196 @@ public class AnalyticsServiceElasticsearchTest {
         assertEquals(1, in1.getOutbound().get("out1.1").getCount());
         assertEquals(2, in1.getOutbound().get("out1.2").getCount());
         assertEquals(2, in2.getOutbound().get("out2.1").getCount());
+    }
+
+    @Test
+    public void testGetCommunicationSummaryStatisticsWithOps() {
+        List<CommunicationDetails> cds = new ArrayList<CommunicationDetails>();
+        List<CompletionTime> cts = new ArrayList<CompletionTime>();
+
+        CompletionTime ct1_1 = new CompletionTime();
+        ct1_1.setUri("in1");
+        ct1_1.setOperation("op1");
+        ct1_1.setBusinessTransaction("testapp");
+        ct1_1.setTimestamp(1500);
+        ct1_1.setDuration(100);
+        cts.add(ct1_1);
+
+        CompletionTime ct1_2 = new CompletionTime();
+        ct1_2.setUri("out1.1");
+        ct1_2.setOperation("op1.1");
+        ct1_2.setBusinessTransaction("testapp");
+        ct1_2.setTimestamp(1600);
+        ct1_2.setDuration(300);
+        cts.add(ct1_2);
+
+        CompletionTime ct1_3 = new CompletionTime();
+        ct1_3.setUri("out1.2");
+        ct1_3.setOperation("op1.2");
+        ct1_3.setBusinessTransaction("testapp");
+        ct1_3.setTimestamp(1600);
+        ct1_3.setDuration(200);
+        cts.add(ct1_3);
+
+        CompletionTime ct2_1 = new CompletionTime();
+        ct2_1.setUri("in2");
+        ct2_1.setOperation("op2");
+        ct2_1.setBusinessTransaction("testapp");
+        ct2_1.setTimestamp(1600);
+        ct2_1.setDuration(500);
+        cts.add(ct2_1);
+
+        CompletionTime ct2_2 = new CompletionTime();
+        ct2_2.setUri("out2.1");
+        ct2_2.setOperation("op2.1");
+        ct2_2.setBusinessTransaction("testapp");
+        ct2_2.setTimestamp(1700);
+        ct2_2.setDuration(400);
+        cts.add(ct2_2);
+
+        CompletionTime ct2_3 = new CompletionTime();
+        ct2_3.setUri("in2");
+        ct2_3.setOperation("op2");
+        ct2_3.setBusinessTransaction("testapp");
+        ct2_3.setTimestamp(1700);
+        ct2_3.setDuration(600);
+        cts.add(ct2_3);
+
+        try {
+            analytics.storeFragmentCompletionTimes(null, cts);
+
+            synchronized (this) {
+                wait(1000);
+            }
+        } catch (Exception e) {
+            fail("Failed to store: " + e);
+        }
+
+        CommunicationDetails cd1 = new CommunicationDetails();
+        cd1.setId("cd1");
+        cd1.setBusinessTransaction("testapp");
+        cd1.setTimestamp(1500);
+        cd1.setLatency(100);
+        cd1.setSource("in1[op1]");
+        cd1.setTarget("out1.1[op1.1]");
+        cds.add(cd1);
+
+        CommunicationDetails cd2 = new CommunicationDetails();
+        cd2.setId("cd2");
+        cd2.setBusinessTransaction("testapp");
+        cd2.setTimestamp(1500);
+        cd2.setLatency(200);
+        cd2.setSource("in1[op1]");
+        cd2.setTarget("out1.2[op1.2]");
+        cds.add(cd2);
+
+        CommunicationDetails cd3 = new CommunicationDetails();
+        cd3.setId("cd3");
+        cd3.setBusinessTransaction("testapp");
+        cd3.setTimestamp(1500);
+        cd3.setLatency(300);
+        cd3.setSource("in2[op2]");
+        cd3.setTarget("out2.1[op2.1]");
+        cds.add(cd3);
+
+        CommunicationDetails cd4 = new CommunicationDetails();
+        cd4.setId("cd4");
+        cd4.setBusinessTransaction("testapp");
+        cd4.setTimestamp(1600);
+        cd4.setLatency(300);
+        cd4.setSource("in1[op1]");
+        cd4.setTarget("out1.2[op1.2]");
+        cds.add(cd4);
+
+        CommunicationDetails cd5 = new CommunicationDetails();
+        cd5.setId("cd5");
+        cd5.setBusinessTransaction("testapp");
+        cd5.setTimestamp(1600);
+        cd5.setLatency(500);
+        cd5.setSource("in2[op2]");
+        cd5.setTarget("out2.1[op2.1]");
+        cds.add(cd5);
+
+        try {
+            analytics.storeCommunicationDetails(null, cds);
+
+            synchronized (this) {
+                wait(1000);
+            }
+        } catch (Exception e) {
+            fail("Failed to store: " + e);
+        }
+
+        Criteria criteria = new Criteria();
+        criteria.setStartTime(1000).setEndTime(10000);
+
+        Collection<CommunicationSummaryStatistics> stats = analytics.getCommunicationSummaryStatistics(null, criteria);
+
+        assertNotNull(stats);
+        assertEquals(5, stats.size());
+
+        CommunicationSummaryStatistics in1 = null;
+        CommunicationSummaryStatistics in2 = null;
+        CommunicationSummaryStatistics out1_1 = null;
+        CommunicationSummaryStatistics out1_2 = null;
+        CommunicationSummaryStatistics out2_1 = null;
+
+        for (CommunicationSummaryStatistics css : stats) {
+            if (css.getId().equals("in1[op1]")) {
+                in1 = css;
+            } else if (css.getId().equals("in2[op2]")) {
+                in2 = css;
+            } else if (css.getId().equals("out1.1[op1.1]")) {
+                out1_1 = css;
+            } else if (css.getId().equals("out1.2[op1.2]")) {
+                out1_2 = css;
+            } else if (css.getId().equals("out2.1[op2.1]")) {
+                out2_1 = css;
+            } else {
+                fail("Unexpected id: " + css.getId());
+            }
+        }
+
+        assertNotNull(in1);
+        assertNotNull(in2);
+        assertNotNull(out1_1);
+        assertNotNull(out1_2);
+        assertNotNull(out2_1);
+
+        assertEquals(1, in1.getCount());
+        assertEquals(2, in2.getCount());
+        assertEquals(1, out1_1.getCount());
+        assertEquals(1, out1_2.getCount());
+        assertEquals(1, out2_1.getCount());
+
+        // Only check in2 node, as others only have single completion time
+        assertTrue(500 == in2.getMinimumDuration());
+        assertTrue(550 == in2.getAverageDuration());
+        assertTrue(600 == in2.getMaximumDuration());
+
+        assertEquals(2, in1.getOutbound().size());
+        assertEquals(1, in2.getOutbound().size());
+        assertEquals(0, out1_1.getOutbound().size());
+        assertEquals(0, out1_2.getOutbound().size());
+        assertEquals(0, out2_1.getOutbound().size());
+
+        assertTrue(in1.getOutbound().containsKey("out1.1[op1.1]"));
+        assertTrue(in1.getOutbound().containsKey("out1.2[op1.2]"));
+        assertTrue(in2.getOutbound().containsKey("out2.1[op2.1]"));
+
+        assertTrue(100 == in1.getOutbound().get("out1.1[op1.1]").getMinimumLatency());
+        assertTrue(100 == in1.getOutbound().get("out1.1[op1.1]").getAverageLatency());
+        assertTrue(100 == in1.getOutbound().get("out1.1[op1.1]").getMaximumLatency());
+        assertTrue(200 == in1.getOutbound().get("out1.2[op1.2]").getMinimumLatency());
+        assertTrue(250 == in1.getOutbound().get("out1.2[op1.2]").getAverageLatency());
+        assertTrue(300 == in1.getOutbound().get("out1.2[op1.2]").getMaximumLatency());
+        assertTrue(300 == in2.getOutbound().get("out2.1[op2.1]").getMinimumLatency());
+        assertTrue(400 == in2.getOutbound().get("out2.1[op2.1]").getAverageLatency());
+        assertTrue(500 == in2.getOutbound().get("out2.1[op2.1]").getMaximumLatency());
+
+        assertEquals(1, in1.getOutbound().get("out1.1[op1.1]").getCount());
+        assertEquals(2, in1.getOutbound().get("out1.2[op1.2]").getCount());
+        assertEquals(2, in2.getOutbound().get("out2.1[op2.1]").getCount());
     }
 
     @Test

--- a/tests/container/jetty/src/test/java/org/hawkular/btm/tests/client/jetty/ClientJettyReaderWriterAsyncTest.java
+++ b/tests/container/jetty/src/test/java/org/hawkular/btm/tests/client/jetty/ClientJettyReaderWriterAsyncTest.java
@@ -264,6 +264,7 @@ public class ClientJettyReaderWriterAsyncTest extends ClientTestBase {
             assertEquals(QUERY_STRING, testConsumer.getDetails().get("http_query"));
         }
 
+        assertEquals(method, testConsumer.getOperation());
         assertEquals(method, testConsumer.getDetails().get("http_method"));
 
         // Check headers

--- a/tests/container/jetty/src/test/java/org/hawkular/btm/tests/client/jetty/ClientJettyReaderWriterTest.java
+++ b/tests/container/jetty/src/test/java/org/hawkular/btm/tests/client/jetty/ClientJettyReaderWriterTest.java
@@ -262,6 +262,7 @@ public class ClientJettyReaderWriterTest extends ClientTestBase {
             assertEquals(QUERY_STRING, testConsumer.getDetails().get("http_query"));
         }
 
+        assertEquals(method, testConsumer.getOperation());
         assertEquals(method, testConsumer.getDetails().get("http_method"));
 
         // Check headers

--- a/tests/container/jetty/src/test/java/org/hawkular/btm/tests/client/jetty/ClientJettyStreamAsyncTest.java
+++ b/tests/container/jetty/src/test/java/org/hawkular/btm/tests/client/jetty/ClientJettyStreamAsyncTest.java
@@ -267,6 +267,7 @@ public class ClientJettyStreamAsyncTest extends ClientTestBase {
             assertEquals(QUERY_STRING, testConsumer.getDetails().get("http_query"));
         }
 
+        assertEquals(method, testConsumer.getOperation());
         assertEquals(method, testConsumer.getDetails().get("http_method"));
 
         // Check headers

--- a/tests/container/jetty/src/test/java/org/hawkular/btm/tests/client/jetty/ClientJettyStreamTest.java
+++ b/tests/container/jetty/src/test/java/org/hawkular/btm/tests/client/jetty/ClientJettyStreamTest.java
@@ -363,6 +363,7 @@ public class ClientJettyStreamTest extends ClientTestBase {
             assertEquals(QUERY_STRING, testConsumer.getDetails().get("http_query"));
         }
 
+        assertEquals(method, testConsumer.getOperation());
         assertEquals(method, testConsumer.getDetails().get("http_method"));
 
         // Check headers

--- a/tests/instrumentation/src/test/java/org/hawkular/btm/tests/client/http/NettyHttpTest.java
+++ b/tests/instrumentation/src/test/java/org/hawkular/btm/tests/client/http/NettyHttpTest.java
@@ -134,6 +134,7 @@ public class NettyHttpTest extends ClientTestBase {
 
         assertEquals(PATH_1, testProducer.getUri());
         assertEquals(QUERY_1, testProducer.getDetails().get("http_query"));
+        assertEquals("GET", testProducer.getOperation());
         assertEquals("GET", testProducer.getDetails().get("http_method"));
     }
 
@@ -186,6 +187,7 @@ public class NettyHttpTest extends ClientTestBase {
 
         assertEquals(PATH_2, testProducer.getUri());
         assertFalse(testProducer.getDetails().containsKey("http_query"));
+        assertEquals("POST", testProducer.getOperation());
         assertEquals("POST", testProducer.getDetails().get("http_method"));
     }
 
@@ -238,6 +240,7 @@ public class NettyHttpTest extends ClientTestBase {
 
         assertEquals(PATH_3, testProducer.getUri());
         assertFalse(testProducer.getDetails().containsKey("http_query"));
+        assertEquals("PUT", testProducer.getOperation());
         assertEquals("PUT", testProducer.getDetails().get("http_method"));
     }
 }

--- a/tests/instrumentation/src/test/java/org/hawkular/btm/tests/client/http/NettyNoResponseHttpTest.java
+++ b/tests/instrumentation/src/test/java/org/hawkular/btm/tests/client/http/NettyNoResponseHttpTest.java
@@ -136,6 +136,7 @@ public class NettyNoResponseHttpTest extends ClientTestBase {
 
         assertEquals(PATH_1, testProducer.getUri());
         assertEquals(QUERY_1, testProducer.getDetails().get("http_query"));
+        assertEquals("GET", testProducer.getOperation());
         assertEquals("GET", testProducer.getDetails().get("http_method"));
     }
 
@@ -188,6 +189,7 @@ public class NettyNoResponseHttpTest extends ClientTestBase {
 
         assertEquals(PATH_2, testProducer.getUri());
         assertFalse(testProducer.getDetails().containsKey("http_query"));
+        assertEquals("POST", testProducer.getOperation());
         assertEquals("POST", testProducer.getDetails().get("http_method"));
     }
 
@@ -240,6 +242,7 @@ public class NettyNoResponseHttpTest extends ClientTestBase {
 
         assertEquals(PATH_3, testProducer.getUri());
         assertFalse(testProducer.getDetails().containsKey("http_query"));
+        assertEquals("PUT", testProducer.getOperation());
         assertEquals("PUT", testProducer.getDetails().get("http_method"));
     }
 }

--- a/tests/server/wildfly/src/test/java/org/hawkular/btm/tests/wildfly/AnalyticsServiceRESTTest.java
+++ b/tests/server/wildfly/src/test/java/org/hawkular/btm/tests/wildfly/AnalyticsServiceRESTTest.java
@@ -1550,12 +1550,12 @@ public class AnalyticsServiceRESTTest {
         CommunicationSummaryStatistics second = null;
 
         for (CommunicationSummaryStatistics css : stats) {
-            if (css.getUri().equals("originuri")) {
+            if (css.getId().equals("originuri")) {
                 first = css;
-            } else if (css.getUri().equals("testuri")) {
+            } else if (css.getId().equals("testuri")) {
                 second = css;
             } else {
-                fail("Unknown uri: " + css.getUri());
+                fail("Unknown uri: " + css.getId());
             }
         }
 
@@ -1565,7 +1565,7 @@ public class AnalyticsServiceRESTTest {
         assertEquals(1, first.getOutbound().size());
         assertEquals(0, second.getOutbound().size());
 
-        assertEquals(first.getOutbound().keySet().iterator().next(), second.getUri());
+        assertEquals(first.getOutbound().keySet().iterator().next(), second.getId());
     }
 
     @Test
@@ -1688,12 +1688,12 @@ public class AnalyticsServiceRESTTest {
         CommunicationSummaryStatistics second = null;
 
         for (CommunicationSummaryStatistics css : stats) {
-            if (css.getUri().equals("originuri")) {
+            if (css.getId().equals("originuri")) {
                 first = css;
-            } else if (css.getUri().equals("testuri")) {
+            } else if (css.getId().equals("testuri")) {
                 second = css;
             } else {
-                fail("Unknown uri: " + css.getUri());
+                fail("Unknown uri: " + css.getId());
             }
         }
 
@@ -1703,7 +1703,7 @@ public class AnalyticsServiceRESTTest {
         assertEquals(1, first.getOutbound().size());
         assertEquals(0, second.getOutbound().size());
 
-        assertEquals(first.getOutbound().keySet().iterator().next(), second.getUri());
+        assertEquals(first.getOutbound().keySet().iterator().next(), second.getId());
     }
 
     @Test


### PR DESCRIPTION
…Component nodes, as an additional qualifier for Producer/Consumer nodes - so for example with REST calls it will be used to hold the http method. This is to ensure that distinct transactions that use the same REST endpoint URI, are correctly distinguished by the method. Also updated the communication details summary (graph) to ensure the URI and optional operation are used to determine the endpoints.