### PR TITLE
Fix APM Hostname typeahead, early setting model

### DIFF
--- a/ui/src/main/scripts/plugins/apm/html/apm.html
+++ b/ui/src/main/scripts/plugins/apm/html/apm.html
@@ -23,10 +23,10 @@
 
     <div class="hk-filter-v-block">
       <label><button class="btn-link" ng-click="showSearchHost = !showSearchHost"><i class="fa" ng-class="showSearchHost ? 'fa-plus-square' : 'fa-minus-square'"></i> Host Name </button></label>
-      <input collapse="showSearchHost" type="text" class="form-control" name="hostNameField" typeahead-on-select="selectAction()"
-                 ng-model="criteria.hostName" ng-model-options="{ updateOn: 'default blur'}"
-                 placeholder="Enter a host name"
-                 typeahead="hostName for hostName in hostNames | filter:$viewValue | limitTo:12" />
+      <input collapse="showSearchHost" type="text" class="form-control" name="hostNameField"
+         ng-model="criteria.hostName" ng-model-options="{ updateOn: 'default blur' }"
+         placeholder="Enter a host name" typeahead-editable="false"
+         typeahead="hostName for hostName in hostNames | filter:$viewValue | limitTo:12" />
     </div>
   </div>
 </div>
@@ -59,8 +59,7 @@
       <form class="form-inline">
         <div class="form-group">
           <label for="intervalField">Aggregation Interval:</label>
-          <select class="form-control" id="intervalField" ng-model="config.interval"
-                  ng-change="selectAction()">
+          <select class="form-control" id="intervalField" ng-model="config.interval">
             <option value="1000">1 Second</option>
             <option value="10000">10 Second</option>
             <option value="30000">30 Second</option>
@@ -73,8 +72,7 @@
         </div>
         <div class="form-group">
           <label for="timeSpanField">Time Span:</label>
-          <select class="form-control" id="timeSpanField" ng-model="criteria.startTime"
-                  ng-change="selectAction()">
+          <select class="form-control" id="timeSpanField" ng-model="criteria.startTime">
             <option value="-60000">1 Minute</option>
             <option value="-600000">10 Minutes</option>
             <option value="-1800000">30 Minutes</option>


### PR DESCRIPTION
With typeahead-editable="false" the ng-model is only updated when the
option is valid. This makes it that while typing, there isn't an update
to the model causing several refreshes with invalid host.

Also removed non-used method calls to selectAction.