### PR TITLE
HWKBTM-407 Whenever a separate thread is spawned to handle a set of a…

### DIFF
--- a/client/btxn-instrumentation/src/main/resources/btmconfig/io/netty/btm-netty.json
+++ b/client/btxn-instrumentation/src/main/resources/btmconfig/io/netty/btm-netty.json
@@ -33,7 +33,8 @@
         "condition": "isCorrelated(\"io.netty-async-\"+hashCode($0))",
         "actions": [{
           "type": "CompleteCorrelation",
-          "idExpression": "\"io.netty-async-\"+hashCode($0)"
+          "idExpression": "\"io.netty-async-\"+hashCode($0)",
+          "allowSpawn": true
         }]
       }]
     }


### PR DESCRIPTION
…ctivities, delegate the monitoring of these activities to a separate btxn fragment, to avoid issues when constructing the fragment node hierarchy.