### PR TITLE
HWKBTM-415 : Force tooltip removal on refresh

### DIFF
--- a/ui/src/main/scripts/plugins/directives/dagre-d3/ts/dagreD3Directive.ts
+++ b/ui/src/main/scripts/plugins/directives/dagre-d3/ts/dagreD3Directive.ts
@@ -69,11 +69,16 @@ module DagreD3 {
           });
         }
 
+        // force removing existing tooltips, otherwise they'll get sticky
+        angular.element('.graph-tooltip').remove();
+
         _.each(scope[attrs.nodes], (d) => {
           let className = d.averageDuration < 500 ? 'success' : 'danger';
-          let nodeTooltip = '<strong>Duration</strong> (avg/min/max) <br>' + d.averageDuration;
+          let nodeTooltip = '<strong>' + d.id + '</strong><hr/><strong>Duration</strong> (avg/min/max) <br>' +
+            d.averageDuration;
           nodeTooltip += ' / ' + d.minimumDuration + ' / ' + d.maximumDuration;
-          let html = '<div tooltip-append-to-body="true" tooltip-html-unsafe="' + nodeTooltip + '">';
+          let html = '<div tooltip-append-to-body="true" tooltip-class="graph-tooltip"' +
+            'tooltip-html-unsafe="' + nodeTooltip + '">';
           html += '<span class="status"></span>';
           html += '<span class="node-count pull-right">' + d.count + '</span>';
           html += '<span class="name">' + d.id + '</span>';
@@ -91,7 +96,8 @@ module DagreD3 {
             _.each(Object.keys(d.outbound), (nd: any) => {
               let linkTooltip = '<strong>Latency</strong> (avg/min/max) <br>' + d.outbound[nd].averageLatency;
               linkTooltip += ' / ' + d.outbound[nd].minimumLatency + ' / ' + d.outbound[nd].maximumLatency;
-              let linkHtml = '<span tooltip-append-to-body="true" tooltip-placement="bottom" tooltip-html-unsafe="';
+              let linkHtml = '<span tooltip-append-to-body="true" tooltip-class="graph-tooltip" ' +
+                'tooltip-placement="bottom" tooltip-html-unsafe="';
               linkHtml += linkTooltip + '">' + d.outbound[nd].count + '</span>';
               g.setEdge(d.id, nd, {
                 labelType: 'html',

--- a/ui/src/main/scripts/plugins/e2e/less/e2e.less
+++ b/ui/src/main/scripts/plugins/e2e/less/e2e.less
@@ -61,6 +61,11 @@ th {
     }
 }
 
+.graph-tooltip hr {
+    margin-top: 5px;
+    margin-bottom: 5px;
+}
+
 /* Diagram styles */
 
 .graph {


### PR DESCRIPTION
Force removal of tooltips on graph refresh, otherwise they will stick in
as their trigger element is replaced.

Also added the node id to the tooltip text.