### PR TITLE
HWKBTM-442 Implement store and retrieval of session state for use by …

### DIFF
--- a/api/src/main/java/org/hawkular/btm/api/model/config/instrumentation/InstrumentAction.java
+++ b/api/src/main/java/org/hawkular/btm/api/model/config/instrumentation/InstrumentAction.java
@@ -32,15 +32,15 @@ import io.swagger.annotations.ApiModel;
     @Type(value = InstrumentProducer.class), @Type(value = FreeFormAction.class),
     @Type(value = ProcessContent.class), @Type(value = SetDetail.class),
     @Type(value = SetFault.class), @Type(value = SetName.class), @Type(value = SetLevel.class),
-    @Type(value = SetProperty.class), @Type(value = InitiateCorrelation.class),
+    @Type(value = SetProperty.class), @Type(value = SetState.class), @Type(value = InitiateCorrelation.class),
     @Type(value = CompleteCorrelation.class), @Type(value = Correlate.class),
     @Type(value = Unlink.class), @Type(value = AssertComplete.class), @Type(value = Suppress.class),
     @Type(value = ProcessHeaders.class), @Type(value = SetPrincipal.class), @Type(value = IgnoreNode.class) })
 @ApiModel(subTypes = { InstrumentComponent.class, InstrumentConsumer.class,
         InstrumentProducer.class, FreeFormAction.class, ProcessContent.class,
-        SetDetail.class, SetFault.class, SetName.class, SetLevel.class, SetProperty.class, InitiateCorrelation.class,
-        CompleteCorrelation.class, Correlate.class, Unlink.class, AssertComplete.class, Suppress.class,
-        ProcessHeaders.class, SetPrincipal.class, IgnoreNode.class },
+        SetDetail.class, SetFault.class, SetName.class, SetLevel.class, SetProperty.class, SetState.class,
+        InitiateCorrelation.class, CompleteCorrelation.class, Correlate.class, Unlink.class,
+        AssertComplete.class, Suppress.class, ProcessHeaders.class, SetPrincipal.class, IgnoreNode.class },
         discriminator = "type")
 public abstract class InstrumentAction {
 

--- a/api/src/main/java/org/hawkular/btm/api/model/config/instrumentation/SetState.java
+++ b/api/src/main/java/org/hawkular/btm/api/model/config/instrumentation/SetState.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.btm.api.model.config.instrumentation;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * This type represents the action for setting state.
+ *
+ * @author gbrown
+ */
+public class SetState extends InstrumentAction {
+
+    @JsonInclude
+    private String contextExpression;
+
+    @JsonInclude
+    private String name;
+
+    @JsonInclude
+    private String valueExpression;
+
+    @JsonInclude
+    private boolean session;
+
+    /**
+     * @return the contextExpression
+     */
+    public String getContextExpression() {
+        return contextExpression;
+    }
+
+    /**
+     * @param contextExpression the contextExpression to set
+     */
+    public void setContextExpression(String contextExpression) {
+        this.contextExpression = contextExpression;
+    }
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param name the name to set
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return the valueExpression
+     */
+    public String getValueExpression() {
+        return valueExpression;
+    }
+
+    /**
+     * @param valueExpression the valueExpression to set
+     */
+    public void setValueExpression(String valueExpression) {
+        this.valueExpression = valueExpression;
+    }
+
+    /**
+     * @return the session
+     */
+    public boolean isSession() {
+        return session;
+    }
+
+    /**
+     * @param session the session to set
+     */
+    public void setSession(boolean session) {
+        this.session = session;
+    }
+
+}

--- a/client/api/src/main/java/org/hawkular/btm/client/api/SessionManager.java
+++ b/client/api/src/main/java/org/hawkular/btm/client/api/SessionManager.java
@@ -155,4 +155,26 @@ public interface SessionManager {
      */
     void assertComplete();
 
+    /**
+     * This method stores state information associated with the name and optional
+     * context.
+     *
+     * @param context The optional context
+     * @param name The name
+     * @param value The value
+     * @param session Whether related to session
+     */
+    void setState(Object context, String name, Object value, boolean session);
+
+    /**
+     * This method returns the state associated with the name and optional
+     * context.
+     *
+     * @param context The optional context
+     * @param name The name
+     * @param session Whether related to session
+     * @return The state, or null if not found
+     */
+    Object getState(Object context, String name, boolean session);
+
 }

--- a/client/btxn-collector/src/main/java/org/hawkular/btm/client/collector/DefaultBusinessTransactionCollector.java
+++ b/client/btxn-collector/src/main/java/org/hawkular/btm/client/collector/DefaultBusinessTransactionCollector.java
@@ -1799,6 +1799,68 @@ public class DefaultBusinessTransactionCollector implements BusinessTransactionC
     }
 
     /* (non-Javadoc)
+     * @see org.hawkular.btm.client.api.SessionManager#setState(java.lang.Object, java.lang.String, java.lang.Object, boolean)
+     */
+    @Override
+    public void setState(Object context, String name, Object value, boolean session) {
+        if (log.isLoggable(Level.FINEST)) {
+            log.finest("Set state: context=" + context + " name=" + name + " value="
+                    + value + " session=" + session);
+        }
+
+        if (session) {
+            try {
+                FragmentBuilder builder = fragmentManager.getFragmentBuilder();
+
+                if (builder != null) {
+                    builder.setState(context, name, value);
+                }
+            } catch (Throwable t) {
+                if (log.isLoggable(warningLogLevel)) {
+                    log.log(warningLogLevel, "setState failed", t);
+                }
+            }
+        } else {
+            throw new UnsupportedOperationException("Only session state supported currently");
+        }
+    }
+
+    /* (non-Javadoc)
+     * @see org.hawkular.btm.client.api.SessionManager#getState(java.lang.Object, java.lang.String, boolean)
+     */
+    @Override
+    public Object getState(Object context, String name, boolean session) {
+        Object ret = null;
+
+        if (log.isLoggable(Level.FINEST)) {
+            log.finest("Get state: context=" + context + " name=" + name + " session=" + session);
+        }
+
+        if (session) {
+            try {
+                FragmentBuilder builder = fragmentManager.getFragmentBuilder();
+
+                if (builder != null) {
+                    ret = builder.getState(context, name);
+                }
+            } catch (Throwable t) {
+                if (log.isLoggable(warningLogLevel)) {
+                    log.log(warningLogLevel, "getState failed", t);
+                }
+            }
+        } else {
+            throw new UnsupportedOperationException("Only session state supported currently");
+        }
+
+        if (log.isLoggable(Level.FINEST)) {
+            log.finest("Get state: context=" + context + " name=" + name + " session="
+                    + session + " value is: " + ret);
+        }
+
+        return ret;
+    }
+
+    /* (non-Javadoc)
      * @see org.hawkular.btm.api.client.BusinessTransactionCollector#session()
      */
     @Override

--- a/client/btxn-collector/src/main/java/org/hawkular/btm/client/collector/internal/FragmentBuilder.java
+++ b/client/btxn-collector/src/main/java/org/hawkular/btm/client/collector/internal/FragmentBuilder.java
@@ -62,6 +62,8 @@ public class FragmentBuilder {
 
     private Map<String,NodePlaceholder> uncompletedCorrelationIdsNodeMap = new HashMap<String,NodePlaceholder>();
 
+    private Map<String,StateInformation> stateInformation = new HashMap<String,StateInformation>();
+
     private boolean suppress = false;
 
     private static String hostName;
@@ -576,6 +578,39 @@ public class FragmentBuilder {
     }
 
     /**
+     * This method stores state information associated with the name and optional
+     * context.
+     *
+     * @param context The optional context
+     * @param name The name
+     * @param value The value
+     */
+    public void setState(Object context, String name, Object value) {
+        StateInformation si = stateInformation.get(name);
+        if (si == null) {
+            si = new StateInformation();
+            stateInformation.put(name, si);
+        }
+        si.set(context, value);
+    }
+
+    /**
+     * This method returns the state associated with the name and optional
+     * context.
+     *
+     * @param context The optional context
+     * @param name The name
+     * @return The state, or null if not found
+     */
+    public Object getState(Object context, String name) {
+        StateInformation si = stateInformation.get(name);
+        if (si == null) {
+            return null;
+        }
+        return si.get(context);
+    }
+
+    /**
      * @return The thread count
      */
     public int getThreadCount() {
@@ -670,5 +705,58 @@ public class FragmentBuilder {
             return "NodePlaceholder [node=" + node + ", position=" + position + "]";
         }
 
+    }
+
+    /**
+     * This class provides management of context to value state.
+     *
+     * @author gbrown
+     */
+    public static class StateInformation {
+
+        private Object noContextValue = null;
+        private Map<Object,Object> contextToValueMap = new HashMap<Object,Object>();
+
+        /**
+         * This method sets the value associated with an optional context.
+         *
+         * @param context The optional context
+         * @param value The value
+         */
+        public void set(Object context, Object value) {
+            if (context == null) {
+                noContextValue = value;
+            } else {
+                contextToValueMap.put(context, value);
+            }
+        }
+
+        /**
+         * This method retrieves the value associated with an optional
+         * context.
+         *
+         * @param context The optional context
+         * @return The value, or null if not found
+         */
+        public Object get(Object context) {
+            if (context == null) {
+                return noContextValue;
+            }
+            return contextToValueMap.get(context);
+        }
+
+        /**
+         * This method removes the value associated with the supplied
+         * optional context.
+         *
+         * @param context The optional context
+         */
+        public void remove(Object context) {
+            if (context == null) {
+                noContextValue = null;
+            } else {
+                contextToValueMap.remove(context);
+            }
+        }
     }
 }

--- a/client/btxn-instrumentation/src/main/resources/btmconfig/java/btm-java-jdbc.json
+++ b/client/btxn-instrumentation/src/main/resources/btmconfig/java/btm-java-jdbc.json
@@ -3,6 +3,55 @@
     "java.sql": {
       "description": "Java JDBC instrumentation",
       "rules": [{
+        "ruleName": "Java JDBC Execute Component Start",
+        "notes": [
+          "HWKBTM-413 - added no compile due to IllegalAccessError in oracle jdbc driver"
+        ],
+        "interfaceName": "^java.sql.Statement",
+        "methodName": "execute",
+        "parameterTypes": [
+          "*"
+        ],
+        "location": "ENTRY",
+        "compile": false,
+        "condition": "isActive()",
+        "actions": [{
+          "type": "InstrumentComponent",
+          "direction": "In",
+          "componentTypeExpression": "\"Database\"",
+          "operationExpression": "\"execute\"",
+          "uriExpression": "$0.getConnection().getMetaData().getURL()"
+        },{
+          "type": "SetDetail",
+          "name": "statement",
+          "valueExpression": "$1"
+        },{
+          "type": "SetDetail",
+          "name": "action",
+          "valueExpression": "\"execute\""
+        },{
+          "type": "SetDetail",
+          "name": "btm_source",
+          "valueExpression": "\"java.sql\""
+        },{
+          "type": "Suppress"
+        }]
+      },{
+        "ruleName": "Java JDBC Execute Component End",
+        "interfaceName": "^java.sql.Statement",
+        "methodName": "execute",
+        "parameterTypes": [
+          "*"
+        ],
+        "location": "EXIT",
+        "condition": "isActive()",
+        "actions": [{
+          "type": "InstrumentComponent",
+          "direction": "Out",
+          "componentTypeExpression": "\"Database\"",
+          "uriExpression": "$0.getConnection().getMetaData().getURL()"
+        }]
+      },{
         "ruleName": "Java JDBC Query Component Start",
         "notes": [
           "HWKBTM-413 - added no compile due to IllegalAccessError in oracle jdbc driver"
@@ -24,7 +73,7 @@
         },{
           "type": "SetDetail",
           "name": "statement",
-          "valueExpression": "formatSQL($0)"
+          "valueExpression": "$1"
         },{
           "type": "SetDetail",
           "name": "action",
@@ -52,49 +101,6 @@
           "uriExpression": "$0.getConnection().getMetaData().getURL()"
         }]
       },{
-        "ruleName": "Java JDBC Prepared Query Component Start",
-        "interfaceName": "^java.sql.PreparedStatement",
-        "methodName": "executeQuery",
-        "parameterTypes": [
-        ],
-        "location": "ENTRY",
-        "condition": "isActive()",
-        "actions": [{
-          "type": "InstrumentComponent",
-          "direction": "In",
-          "componentTypeExpression": "\"Database\"",
-          "operationExpression": "\"query\"",
-          "uriExpression": "$0.getConnection().getMetaData().getURL()"
-        },{
-          "type": "SetDetail",
-          "name": "statement",
-          "valueExpression": "formatSQL($0)"
-        },{
-          "type": "SetDetail",
-          "name": "action",
-          "valueExpression": "\"query\""
-        },{
-          "type": "SetDetail",
-          "name": "btm_source",
-          "valueExpression": "\"java.sql\""
-        },{
-          "type": "Suppress"
-        }]
-      },{
-        "ruleName": "Java JDBC Prepared Query Component End",
-        "interfaceName": "^java.sql.PreparedStatement",
-        "methodName": "executeQuery",
-        "parameterTypes": [
-        ],
-        "location": "EXIT",
-        "condition": "isActive()",
-        "actions": [{
-          "type": "InstrumentComponent",
-          "direction": "Out",
-          "componentTypeExpression": "\"Database\"",
-          "uriExpression": "$0.getConnection().getMetaData().getURL()"
-        }]
-      },{
         "ruleName": "Java JDBC Update Component Start",
         "interfaceName": "^java.sql.Statement",
         "methodName": "executeUpdate",
@@ -112,7 +118,7 @@
         },{
           "type": "SetDetail",
           "name": "statement",
-          "valueExpression": "formatSQL($0)"
+          "valueExpression": "$1"
         },{
           "type": "SetDetail",
           "name": "action",
@@ -140,6 +146,65 @@
           "uriExpression": "$0.getConnection().getMetaData().getURL()"
         }]
       },{
+        "ruleName": "Java JDBC Create Prepared Statement End",
+        "interfaceName": "^java.sql.Connection",
+        "methodName": "prepareStatement",
+        "parameterTypes": [
+          "*"
+        ],
+        "location": "EXIT",
+        "condition": "isActive()",
+        "actions": [{
+          "type": "SetState",
+          "contextExpression": "$!",
+          "name": "sql",
+          "valueExpression": "$1",
+          "session": true
+        }]
+      },{
+        "ruleName": "Java JDBC Prepared Query Component Start",
+        "interfaceName": "^java.sql.PreparedStatement",
+        "methodName": "executeQuery",
+        "parameterTypes": [
+        ],
+        "location": "ENTRY",
+        "condition": "isActive()",
+        "actions": [{
+          "type": "InstrumentComponent",
+          "direction": "In",
+          "componentTypeExpression": "\"Database\"",
+          "operationExpression": "\"query\"",
+          "uriExpression": "$0.getConnection().getMetaData().getURL()"
+        },{
+          "type": "SetDetail",
+          "name": "statement",
+          "valueExpression": "formatSQL($0,getState($0,\"sql\",true))"
+        },{
+          "type": "SetDetail",
+          "name": "action",
+          "valueExpression": "\"query\""
+        },{
+          "type": "SetDetail",
+          "name": "btm_source",
+          "valueExpression": "\"java.sql\""
+        },{
+          "type": "Suppress"
+        }]
+      },{
+        "ruleName": "Java JDBC Prepared Query Component End",
+        "interfaceName": "^java.sql.PreparedStatement",
+        "methodName": "executeQuery",
+        "parameterTypes": [
+        ],
+        "location": "EXIT",
+        "condition": "isActive()",
+        "actions": [{
+          "type": "InstrumentComponent",
+          "direction": "Out",
+          "componentTypeExpression": "\"Database\"",
+          "uriExpression": "$0.getConnection().getMetaData().getURL()"
+        }]
+      },{
         "ruleName": "Java JDBC Prepared Update Component Start",
         "interfaceName": "^java.sql.PreparedStatement",
         "methodName": "executeUpdate",
@@ -156,7 +221,7 @@
         },{
           "type": "SetDetail",
           "name": "statement",
-          "valueExpression": "formatSQL($0)"
+          "valueExpression": "formatSQL($0,getState($0,\"sql\",true))"
         },{
           "type": "SetDetail",
           "name": "action",

--- a/client/client-manager/src/main/java/org/hawkular/btm/client/manager/config/SetStateTransformer.java
+++ b/client/client-manager/src/main/java/org/hawkular/btm/client/manager/config/SetStateTransformer.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.btm.client.manager.config;
+
+import org.hawkular.btm.api.model.config.instrumentation.InstrumentAction;
+import org.hawkular.btm.api.model.config.instrumentation.SetState;
+
+/**
+ * This class transforms the SetDetail action type.
+ *
+ * @author gbrown
+ */
+public class SetStateTransformer implements InstrumentActionTransformer {
+
+    /* (non-Javadoc)
+     * @see org.hawkular.btm.client.manager.config.InstrumentActionTransformer#getActionType()
+     */
+    @Override
+    public Class<? extends InstrumentAction> getActionType() {
+        return SetState.class;
+    }
+
+    /* (non-Javadoc)
+     * @see org.hawkular.btm.client.manager.config.InstrumentActionTransformer#convertToRuleAction(
+     *                      org.hawkular.btm.api.model.admin.InstrumentAction)
+     */
+    @Override
+    public String convertToRuleAction(InstrumentAction action) {
+        SetState setState = (SetState) action;
+        StringBuilder builder = new StringBuilder();
+
+        builder.append("setState(");
+
+        if (setState.getContextExpression() == null) {
+            builder.append("null");
+        } else {
+            builder.append(setState.getContextExpression());
+        }
+
+        builder.append(",\"");
+
+        builder.append(setState.getName());
+
+        builder.append("\",");
+
+        if (setState.getValueExpression() == null) {
+            builder.append("null");
+        } else {
+            builder.append(setState.getValueExpression());
+        }
+
+        builder.append(",");
+
+        builder.append(setState.isSession());
+
+        builder.append(")");
+
+        return builder.toString();
+    }
+
+}

--- a/client/client-manager/src/main/resources/META-INF/services/org.hawkular.btm.client.manager.config.InstrumentActionTransformer
+++ b/client/client-manager/src/main/resources/META-INF/services/org.hawkular.btm.client.manager.config.InstrumentActionTransformer
@@ -11,6 +11,7 @@ org.hawkular.btm.client.manager.config.SetLevelTransformer
 org.hawkular.btm.client.manager.config.SetNameTransformer
 org.hawkular.btm.client.manager.config.SetPrincipalTransformer
 org.hawkular.btm.client.manager.config.SetPropertyTransformer
+org.hawkular.btm.client.manager.config.SetStateTransformer
 org.hawkular.btm.client.manager.config.InitiateCorrelationTransformer
 org.hawkular.btm.client.manager.config.CorrelateTransformer
 org.hawkular.btm.client.manager.config.CompleteCorrelationTransformer

--- a/client/client-manager/src/test/java/org/hawkular/btm/client/manager/RuleHelperTest.java
+++ b/client/client-manager/src/test/java/org/hawkular/btm/client/manager/RuleHelperTest.java
@@ -94,7 +94,7 @@ public class RuleHelperTest {
                 + "as id1_5_0_, performanc0_.date as date2_5_0_, performanc0_.show_id as show_id3_5_0_ from "
                 + "Performance performanc0_ where performanc0_.show_id=? order by performanc0_.date {1: 1}";
 
-        String result = helper.formatSQL(pretext + sql);
+        String result = helper.formatSQL(pretext + sql, null);
 
         assertEquals(sql, result);
     }
@@ -107,7 +107,7 @@ public class RuleHelperTest {
         String sql = "select mediaitem0_.id as id1_4_0_, mediaitem0_.mediaType as mediaTyp2_4_0_, mediaitem0_.url "
                 + "as url3_4_0_ from MediaItem mediaitem0_ where mediaitem0_.id=? {1: 22}";
 
-        String result = helper.formatSQL(pretext + sql);
+        String result = helper.formatSQL(pretext + sql, null);
 
         assertEquals(sql, result);
     }
@@ -128,9 +128,22 @@ public class RuleHelperTest {
         String pre = pretext + binary + posttext;
         String expected = pretext + RuleHelper.BINARY_SQL_MARKER + posttext;
 
-        String result = helper.formatSQL(pre);
+        String result = helper.formatSQL(pre, null);
 
         assertEquals(expected, result);
+    }
+
+    @Test
+    public void testFormatSQLWithSupplidExpression() {
+        RuleHelper helper = new RuleHelper(null);
+
+        String expr = "theExpression";
+
+        String context = "theContext";
+
+        String result = helper.formatSQL(context, expr);
+
+        assertEquals(expr, result);
     }
 
     public class TestObject1 {


### PR DESCRIPTION
…instrumentation rules. This is required to cache information that may be available prior to its use for creating activity information.

HWKBTM-428 Concrete example being storing the SQL statement prior to its use, as the expression is not directly available at the point the expression is executed. This will only work for prepared statements created prior to use, and not those that are cached and used across sessions.